### PR TITLE
Fixed issue #39 - Now productName takes from PRODUCT_MODULE_NAME

### DIFF
--- a/lua/xcodebuild/xcode.lua
+++ b/lua/xcodebuild/xcode.lua
@@ -253,7 +253,7 @@ function M.get_build_settings(platform, projectCommand, scheme, config, callback
 
       for _, line in ipairs(output) do
         bundleId = bundleId or find_setting(line, "PRODUCT_BUNDLE_IDENTIFIER")
-        productName = productName or find_setting(line, "PRODUCT_NAME")
+        productName = productName or find_setting(line, "PRODUCT_MODULE_NAME")
         buildDir = buildDir or find_setting(line, "TARGET_BUILD_DIR")
 
         if bundleId and productName and buildDir then


### PR DESCRIPTION
[Could not install app (code: 2) #39](https://github.com/wojciech-kulik/xcodebuild.nvim/issues/39)

Use `PRODUCT_MODULE_NAME` as productName instead of `PRODUCT_NAME` 

Also my first opensource contribution, be gentle please)