### PR TITLE
feat: Add list_targets and add_file_to_targets to actions

### DIFF
--- a/lua/xcodebuild/actions.lua
+++ b/lua/xcodebuild/actions.lua
@@ -241,6 +241,14 @@ end
 
 -- Project Management
 
+function M.get_project_targets()
+  return projectManager.get_project_targets()
+end
+
+function M.add_file_to_targets(filepath, targets)
+  projectManager.add_file_to_targets(filepath, targets)
+end
+
 function M.create_new_file()
   projectManager.create_new_file()
 end

--- a/lua/xcodebuild/project/manager.lua
+++ b/lua/xcodebuild/project/manager.lua
@@ -57,8 +57,12 @@ local function run(action, params)
   return output
 end
 
+local function run_list_targets()
+  return run("list_targets")
+end
+
 local function run_select_targets(callback)
-  local targets = run("list_targets")
+  local targets = run_list_targets()
   pickers.show("Select Target(s)", targets, callback, { close_on_select = true, multiselect = true })
 end
 
@@ -126,6 +130,22 @@ function M.create_new_file()
   vim.cmd("e " .. fullPath)
 
   M.add_current_file()
+end
+
+function M.add_file_to_targets(filepath, targets)
+  if not helpers.validate_project() or not validate_xcodeproj_tool() then
+    return
+  end
+
+  run_add_file_to_targets(filepath, targets)
+end
+
+function M.get_project_targets()
+  if not helpers.validate_project() or not validate_xcodeproj_tool() then
+    return
+  end
+
+  return run_list_targets()
 end
 
 function M.add_file(filepath)


### PR DESCRIPTION
Hi!

First of all, thank you for this amazing plugin. I'm having a lot of fun with it :)

I wanted to add files/directories non interactively via autocmds when creating new swift files so I added some small helper functions. Hopefully they are general enough.

However this is as far as I got, I couldn't get `list_targets` to return anything, even though it's identical to the call in `run_select_targets`. Perhaps you see something I don't? And if you like the changes we can merge them.