### PR TITLE
fix: loading settings.json fail without .nvim folder

### DIFF
--- a/lua/xcodebuild/project/config.lua
+++ b/lua/xcodebuild/project/config.lua
@@ -52,7 +52,7 @@ end
 function M.load_settings()
   local success, content = pcall(vim.fn.readfile, get_filepath())
 
-  if success then
+  if success and content ~= 0 then
     M.settings = vim.fn.json_decode(content)
     update_global_variables()
   end


### PR DESCRIPTION
fixed #58 

There is not a `.nvim` folder, and `local success, content = pcall(vim.fn.readfile, get_filepath())` got `content == 0`, `M.settings` got `0`, and crashed the process.