### PR TITLE
fix!: handling build configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,6 @@ Xcodebuild.nvim comes with the following commands:
 | -------------------------- | ----------------------------------- |
 | `XcodebuildSelectProject`  | Show project file picker            |
 | `XcodebuildSelectScheme`   | Show scheme picker                  |
-| `XcodebuildSelectConfig`   | Show build configuration picker     |
 | `XcodebuildSelectDevice`   | Show device picker                  |
 | `XcodebuildSelectTestPlan` | Show test plan picker               |
 | `XcodebuildShowConfig`     | Print current project configuration |

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -453,7 +453,6 @@ Configuration
  | -------------------------| ----------------------------------- |
  | `XcodebuildSelectProject`  | Show project file picker            |
  | `XcodebuildSelectScheme`   | Show scheme picker                  |
- | `XcodebuildSelectConfig`   | Show build configuration picker     |
  | `XcodebuildSelectDevice`   | Show device picker                  |
  | `XcodebuildSelectTestPlan` | Show test plan picker               |
  | `XcodebuildShowConfig`     | Print current project configuration |
@@ -476,7 +475,6 @@ integrate with `lualine` or other plugins.
  | `vim.g.xcodebuild_device_name` | Device name (ex. iPhone 15 Pro)                    |
  | `vim.g.xcodebuild_os`          | OS version (ex. 16.4)                              |
  | `vim.g.xcodebuild_platform`    | Device platform (macOS or iPhone Simulator)        |
- | `vim.g.xcodebuild_config`      | Selected build config (ex. Debug)                  |
  | `vim.g.xcodebuild_scheme`      | Selected project scheme (ex. MyApp)                |
  | `vim.g.xcodebuild_test_plan`   | Selected Test Plan (ex. MyAppTests)                |
  | `vim.g.xcodebuild_last_status` | Last build/test status (ex. Build Succeeded [15s]) |
@@ -677,13 +675,6 @@ M.select_project({callback})                 *xcodebuild.actions.select_project*
 
 M.select_scheme({callback})                   *xcodebuild.actions.select_scheme*
   Starts the pickers with scheme selection.
-
-  Parameters: ~
-    {callback}  (function|nil)
-
-
-M.select_config({callback})                   *xcodebuild.actions.select_config*
-  Starts the pickers with configuration selection.
 
   Parameters: ~
     {callback}  (function|nil)
@@ -982,7 +973,6 @@ XcodeBuildOptions                      *xcodebuild.core.xcode.XcodeBuildOptions*
     {projectCommand}   (string)
     {scheme}           (string)
     {destination}      (string)
-    {config}           (string)
     {extraBuildArgs}   (string|nil)
     {on_stdout}        (function)
     {on_stderr}        (fun(_:any,output:string[],_:any))
@@ -996,7 +986,6 @@ XcodeTestOptions                        *xcodebuild.core.xcode.XcodeTestOptions*
     {projectCommand}   (string)
     {scheme}           (string)
     {destination}      (string)
-    {config}           (string)
     {testPlan}         (string)
     {testsToRun}       (string[]|nil)
     {extraTestArgs}    (string|nil)
@@ -1012,7 +1001,6 @@ XcodeEnumerateOptions
     {projectCommand}  (string)
     {scheme}          (string)
     {destination}     (string)
-    {config}          (string)
     {testPlan}        (string)
     {extraTestArgs}   (string|nil)
 
@@ -1101,15 +1089,16 @@ M.build_project({opts})                    *xcodebuild.core.xcode.build_project*
 
 
                                       *xcodebuild.core.xcode.get_build_settings*
-M.get_build_settings({platform}, {projectCommand}, {scheme}, {config}, {callback})
+M.get_build_settings({platform}, {projectCommand}, {scheme}, {xcodeprojPath}, {callback})
   Returns the build settings for the given project.
+
   If one of the settings is not found, it will send an error notification.
 
   Parameters: ~
     {platform}        (string)
     {projectCommand}  (string)
     {scheme}          (string)
-    {config}          (string)
+    {xcodeprojPath}   (string)
     {callback}        (fun(settings:XcodeBuildSettings))
 
   Returns: ~
@@ -1515,7 +1504,6 @@ ProjectSettings
     {projectFile}     (string|nil) project file path (ex. "path/to/Project.xcodeproj")
     {projectCommand}  (string|nil) project command (ex. "-project 'path/to/Project.xcodeproj'" or "-workspace 'path/to/Project.xcworkspace'")
     {scheme}          (string|nil) scheme name (ex. "MyApp")
-    {config}          (string|nil) configuration name (ex. "Debug")
     {destination}     (string|nil) destination (ex. "28B52DAA-BC2F-410B-A5BE-F485A3AFB0BC")
     {bundleId}        (string|nil) bundle identifier (ex. "com.mycompany.myapp")
     {appPath}         (string|nil) app path (ex. "path/to/MyApp.app")
@@ -3445,28 +3433,15 @@ M.select_project({callback}, {opts})      *xcodebuild.ui.pickers.select_project*
     {opts}      (PickerOptions|nil)
 
 
-                                           *xcodebuild.ui.pickers.select_scheme*
-M.select_scheme({schemes}, {callback}, {opts})
+M.select_scheme({callback}, {opts})        *xcodebuild.ui.pickers.select_scheme*
   Shows a picker with the available schemes.
 
   Parameters: ~
-    {schemes}   (string[]|nil)
     {callback}  (fun(scheme:string)|nil)
     {opts}      (PickerOptions|nil)
 
   Returns: ~
     (number|nil)  id if launched
-
-
-M.select_config({callback}, {opts})        *xcodebuild.ui.pickers.select_config*
-  Shows a picker with the available build configurations.
-
-  Parameters: ~
-    {callback}  (fun(projectConfig:XcodeProjectInfo)|nil)
-    {opts}      (PickerOptions|nil)
-
-  Returns: ~
-    (number|nil)  id
 
 
 M.select_testplan({callback}, {opts})    *xcodebuild.ui.pickers.select_testplan*

--- a/lua/xcodebuild/actions.lua
+++ b/lua/xcodebuild/actions.lua
@@ -180,18 +180,7 @@ function M.select_scheme(callback)
   defer_send("Loading schemes...")
   helpers.cancel_actions()
 
-  pickers.select_scheme(nil, function()
-    update_settings(callback)
-  end, { close_on_select = true })
-end
-
----Starts the pickers with configuration selection.
----@param callback function|nil
-function M.select_config(callback)
-  defer_send("Loading schemes...")
-  helpers.cancel_actions()
-
-  pickers.select_config(function()
+  pickers.select_scheme(function()
     update_settings(callback)
   end, { close_on_select = true })
 end

--- a/lua/xcodebuild/broadcasting/notifications.lua
+++ b/lua/xcodebuild/broadcasting/notifications.lua
@@ -201,8 +201,6 @@ function M.send_project_settings(settings)
 
       - scheme: ]] .. settings.scheme .. [[
 
-      - config: ]] .. settings.config .. [[
-
       - device: ]] .. (settings.deviceName or settings.platform or "-") .. [[
 
       - osVersion: ]] .. (settings.os or "-") .. [[

--- a/lua/xcodebuild/docs/commands.lua
+++ b/lua/xcodebuild/docs/commands.lua
@@ -76,7 +76,6 @@
 --- | -------------------------| ----------------------------------- |
 --- | `XcodebuildSelectProject`  | Show project file picker            |
 --- | `XcodebuildSelectScheme`   | Show scheme picker                  |
---- | `XcodebuildSelectConfig`   | Show build configuration picker     |
 --- | `XcodebuildSelectDevice`   | Show device picker                  |
 --- | `XcodebuildSelectTestPlan` | Show test plan picker               |
 --- | `XcodebuildShowConfig`     | Print current project configuration |

--- a/lua/xcodebuild/docs/global_variables.lua
+++ b/lua/xcodebuild/docs/global_variables.lua
@@ -11,7 +11,6 @@
 --- | `vim.g.xcodebuild_device_name` | Device name (ex. iPhone 15 Pro)                    |
 --- | `vim.g.xcodebuild_os`          | OS version (ex. 16.4)                              |
 --- | `vim.g.xcodebuild_platform`    | Device platform (macOS or iPhone Simulator)        |
---- | `vim.g.xcodebuild_config`      | Selected build config (ex. Debug)                  |
 --- | `vim.g.xcodebuild_scheme`      | Selected project scheme (ex. MyApp)                |
 --- | `vim.g.xcodebuild_test_plan`   | Selected Test Plan (ex. MyAppTests)                |
 --- | `vim.g.xcodebuild_last_status` | Last build/test status (ex. Build Succeeded [15s]) |

--- a/lua/xcodebuild/init.lua
+++ b/lua/xcodebuild/init.lua
@@ -259,7 +259,6 @@ function M.setup(options)
   vim.api.nvim_create_user_command("XcodebuildPicker", call(actions.show_picker), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildSelectProject", call(actions.select_project), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildSelectScheme", call(actions.select_scheme), { nargs = 0 })
-  vim.api.nvim_create_user_command("XcodebuildSelectConfig", call(actions.select_config), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildSelectDevice", call(actions.select_device), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildSelectTestPlan", call(actions.select_testplan), { nargs = 0 })
 

--- a/lua/xcodebuild/project/builder.lua
+++ b/lua/xcodebuild/project/builder.lua
@@ -115,7 +115,6 @@ function M.build_project(opts, callback)
     destination = projectConfig.settings.destination,
     projectCommand = projectConfig.settings.projectCommand,
     scheme = projectConfig.settings.scheme,
-    config = projectConfig.settings.config,
     extraBuildArgs = config.commands.extra_build_args,
   })
 end

--- a/lua/xcodebuild/tests/runner.lua
+++ b/lua/xcodebuild/tests/runner.lua
@@ -90,7 +90,6 @@ function M.show_test_explorer(callback, opts)
 
     M.currentJobId = xcode.enumerate_tests({
       destination = projectConfig.settings.destination,
-      config = projectConfig.settings.config,
       projectCommand = projectConfig.settings.projectCommand,
       scheme = projectConfig.settings.scheme,
       testPlan = projectConfig.settings.testPlan,
@@ -220,7 +219,6 @@ function M.run_tests(testsToRun, opts)
       destination = projectConfig.settings.destination,
       projectCommand = projectConfig.settings.projectCommand,
       scheme = projectConfig.settings.scheme,
-      config = projectConfig.settings.config,
       testPlan = projectConfig.settings.testPlan,
       testsToRun = testsToRun,
       extraTestArgs = config.commands.extra_test_args,

--- a/lua/xcodebuild/ui/pickers.lua
+++ b/lua/xcodebuild/ui/pickers.lua
@@ -264,60 +264,27 @@ function M.select_project(callback, opts)
 end
 
 ---Shows a picker with the available schemes.
----@param schemes string[]|nil
 ---@param callback fun(scheme: string)|nil
 ---@param opts PickerOptions|nil
 ---@return number|nil job id if launched
-function M.select_scheme(schemes, callback, opts)
-  if util.is_empty(schemes) then
-    start_telescope_spinner()
-  end
+function M.select_scheme(callback, opts)
+  start_telescope_spinner()
 
-  M.show("Select Scheme", schemes or {}, function(value, _)
+  M.show("Select Scheme", {}, function(value, _)
     projectConfig.settings.scheme = value
     projectConfig.save_settings()
     update_xcode_build_server_config()
     util.call(callback, value)
   end, opts)
 
-  if util.is_empty(schemes) then
-    local xcodeproj = projectConfig.settings.xcodeproj
-    if not xcodeproj then
-      notifications.send_error("Xcode project file not set")
-      return nil
-    end
-
-    currentJobId = xcode.get_project_information(xcodeproj, function(info)
-      update_results(info.schemes)
-    end)
-
-    return currentJobId
-  end
-end
-
----Shows a picker with the available build configurations.
----@param callback fun(projectConfig: XcodeProjectInfo)|nil
----@param opts PickerOptions|nil
----@return number|nil job id
-function M.select_config(callback, opts)
   local xcodeproj = projectConfig.settings.xcodeproj
-  local projectInfo = nil
-
   if not xcodeproj then
     notifications.send_error("Xcode project file not set")
     return nil
   end
 
-  start_telescope_spinner()
-  M.show("Select Build Configuration", {}, function(value, _)
-    projectConfig.settings.config = value
-    projectConfig.save_settings()
-    util.call(callback, projectInfo)
-  end, opts)
-
   currentJobId = xcode.get_project_information(xcodeproj, function(info)
-    projectInfo = info
-    update_results(info.configs)
+    update_results(info.schemes)
   end)
 
   return currentJobId
@@ -503,7 +470,6 @@ function M.show_all_actions()
 
     "Select Project File",
     "Select Scheme",
-    "Select Build Configuration",
     "Select Device",
     "Select Test Plan",
 
@@ -534,7 +500,6 @@ function M.show_all_actions()
 
     actions.select_project,
     actions.select_scheme,
-    actions.select_config,
     actions.select_device,
     actions.select_testplan,
 


### PR DESCRIPTION
BREAKING CHANGE: Now build configuration is detected based on the selected scheme. `XcodebuildSelectConfig`, `vim.g.xcodebuild_config`, and `actions.select_config` have been removed.

Resolves #95 