### PR TITLE
fix!: removed `XcodebuildSelectProject` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ Xcodebuild.nvim comes with the following commands:
 
 | Command                    | Description                         |
 | -------------------------- | ----------------------------------- |
-| `XcodebuildSelectProject`  | Show project file picker            |
 | `XcodebuildSelectScheme`   | Show scheme picker                  |
 | `XcodebuildSelectDevice`   | Show device picker                  |
 | `XcodebuildSelectTestPlan` | Show test plan picker               |

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -451,7 +451,6 @@ Configuration
 
  | Command                  | Description                         |
  | -------------------------| ----------------------------------- |
- | `XcodebuildSelectProject`  | Show project file picker            |
  | `XcodebuildSelectScheme`   | Show scheme picker                  |
  | `XcodebuildSelectDevice`   | Show device picker                  |
  | `XcodebuildSelectTestPlan` | Show test plan picker               |

--- a/lua/xcodebuild/docs/commands.lua
+++ b/lua/xcodebuild/docs/commands.lua
@@ -74,7 +74,6 @@
 ---
 --- | Command                  | Description                         |
 --- | -------------------------| ----------------------------------- |
---- | `XcodebuildSelectProject`  | Show project file picker            |
 --- | `XcodebuildSelectScheme`   | Show scheme picker                  |
 --- | `XcodebuildSelectDevice`   | Show device picker                  |
 --- | `XcodebuildSelectTestPlan` | Show test plan picker               |

--- a/lua/xcodebuild/init.lua
+++ b/lua/xcodebuild/init.lua
@@ -257,7 +257,6 @@ function M.setup(options)
   -- Pickers
   vim.api.nvim_create_user_command("XcodebuildSetup", call(actions.configure_project), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildPicker", call(actions.show_picker), { nargs = 0 })
-  vim.api.nvim_create_user_command("XcodebuildSelectProject", call(actions.select_project), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildSelectScheme", call(actions.select_scheme), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildSelectDevice", call(actions.select_device), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildSelectTestPlan", call(actions.select_testplan), { nargs = 0 })

--- a/lua/xcodebuild/ui/pickers.lua
+++ b/lua/xcodebuild/ui/pickers.lua
@@ -468,7 +468,6 @@ function M.show_all_actions()
     "Run Selected Tests",
     "Run Failed Tests",
 
-    "Select Project File",
     "Select Scheme",
     "Select Device",
     "Select Test Plan",
@@ -498,7 +497,6 @@ function M.show_all_actions()
     actions.run_selected_tests,
     actions.run_failing_tests,
 
-    actions.select_project,
     actions.select_scheme,
     actions.select_device,
     actions.select_testplan,


### PR DESCRIPTION
User should not be able to change the project file without going through other steps.

To change the project, run wizard.