### PR TITLE
Replace uses of nvim_(buf|win)_set_option() with nvim_set_option_value()

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -3855,6 +3855,28 @@ M.get_major_os_version()               *xcodebuild.helpers.get_major_os_version*
     (number|nil)
 
 
+                                             *xcodebuild.helpers.set_buf_option*
+M.set_buf_option({bufnr}, {name}, {value})
+  Wraps any nvim_buf_set_option() call to ensure forward compatibility.
+  The function is required because nvim_buf_set_option() was deprecated in nvim-0.10.
+
+  Parameters: ~
+    {bufnr}  (number)
+    {name}   (string)
+    {value}  (any)
+
+
+                                             *xcodebuild.helpers.set_win_option*
+M.set_win_option({winnr}, {name}, {value})
+  Wraps any nvim_win_set_option() call to ensure forward compatibility.
+  The function is required because nvim_win_set_option() was deprecated in nvim-0.10.
+
+  Parameters: ~
+    {winnr}  (number)
+    {name}   (string)
+    {value}  (any)
+
+
                                      *xcodebuild.helpers.update_readonly_buffer*
 M.update_readonly_buffer({bufnr}, {updateFoo})
   Enables `modifiable` and updates the buffer using {updateFoo}.

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -3855,8 +3855,8 @@ M.get_major_os_version()               *xcodebuild.helpers.get_major_os_version*
     (number|nil)
 
 
-                                             *xcodebuild.helpers.set_buf_option*
-M.set_buf_option({bufnr}, {name}, {value})
+                                             *xcodebuild.helpers.buf_set_option*
+M.buf_set_option({bufnr}, {name}, {value})
   Wraps any nvim_buf_set_option() call to ensure forward compatibility.
   The function is required because nvim_buf_set_option() was deprecated in nvim-0.10.
 
@@ -3866,8 +3866,8 @@ M.set_buf_option({bufnr}, {name}, {value})
     {value}  (any)
 
 
-                                             *xcodebuild.helpers.set_win_option*
-M.set_win_option({winnr}, {name}, {value})
+                                             *xcodebuild.helpers.win_set_option*
+M.win_set_option({winnr}, {name}, {value})
   Wraps any nvim_win_set_option() call to ensure forward compatibility.
   The function is required because nvim_win_set_option() was deprecated in nvim-0.10.
 

--- a/lua/xcodebuild/helpers.lua
+++ b/lua/xcodebuild/helpers.lua
@@ -95,21 +95,29 @@ function M.get_major_os_version()
   return settings.os and tonumber(vim.split(settings.os, ".", { plain = true })[1]) or nil
 end
 
----Wraps any nvim_buf_set_option() call to ensure backward and forward compatibility.
----The function is required because nvim_buf_set_option was deprecated in nvim-0.10.
----@param bufOrWinID number
+---Wraps any nvim_buf_set_option() call to ensure forward compatibility.
+---The function is required because nvim_buf_set_option() was deprecated in nvim-0.10.
+---@param bufnr number
 ---@param name string
 ---@param value any
----@param win boolean
-function M.nvim_buf_or_win_set_option_fwd_comp(bufOrWinID, name, value, win)
+function M.nvim_buf_set_option_fwd_comp(bufnr, name, value)
   if vim.fn.has("nvim-0.10") == 1 then
-    if win then
-      vim.api.nvim_set_option_value(name, value, { win = bufOrWinID })
-    else
-      vim.api.nvim_set_option_value(name, value, { buf = bufOrWinID })
-    end
+    vim.api.nvim_set_option_value(name, value, { buf = bufnr })
   else
-    vim.api.nvim_buf_set_option(bufOrWinID, name, value)
+    vim.api.nvim_buf_set_option(bufnr, name, value)
+  end
+end
+
+---Wraps any nvim_win_set_option() call to ensure forward compatibility.
+---The function is required because nvim_win_set_option() was deprecated in nvim-0.10.
+---@param winID number
+---@param name string
+---@param value any
+function M.nvim_win_set_option_fwd_comp(winID, name, value)
+  if vim.fn.has("nvim-0.10") == 1 then
+    vim.api.nvim_set_option_value(name, value, { win = winID })
+  else
+    vim.api.nvim_win_set_option(winID, name, value)
   end
 end
 
@@ -122,12 +130,12 @@ function M.update_readonly_buffer(bufnr, updateFoo)
     return
   end
 
-  M.nvim_buf_or_win_set_option_fwd_comp(bufnr, "readonly", false, false)
-  M.nvim_buf_or_win_set_option_fwd_comp(bufnr, "modifiable", true, false)
+  M.nvim_buf_set_option_fwd_comp(bufnr, "readonly", false)
+  M.nvim_buf_set_option_fwd_comp(bufnr, "modifiable", true)
   updateFoo()
-  M.nvim_buf_or_win_set_option_fwd_comp(bufnr, "modifiable", false, false)
-  M.nvim_buf_or_win_set_option_fwd_comp(bufnr, "modified", false, false)
-  M.nvim_buf_or_win_set_option_fwd_comp(bufnr, "readonly", true, false)
+  M.nvim_buf_set_option_fwd_comp(bufnr, "modifiable", false)
+  M.nvim_buf_set_option_fwd_comp(bufnr, "modified", false)
+  M.nvim_buf_set_option_fwd_comp(bufnr, "readonly", true)
 end
 
 return M

--- a/lua/xcodebuild/helpers.lua
+++ b/lua/xcodebuild/helpers.lua
@@ -102,7 +102,7 @@ end
 ---@param value any
 ---@param win boolean
 function M.nvim_buf_or_win_set_option_fwd_comp(bufOrWinID, name, value, win)
-  if vim.fn.has("nvim-0.10") then
+  if vim.fn.has("nvim-0.10") == 1 then
     if win then
       vim.api.nvim_set_option_value(name, value, { win = bufOrWinID })
     else

--- a/lua/xcodebuild/helpers.lua
+++ b/lua/xcodebuild/helpers.lua
@@ -100,7 +100,7 @@ end
 ---@param bufnr number
 ---@param name string
 ---@param value any
-function M.set_buf_option(bufnr, name, value)
+function M.buf_set_option(bufnr, name, value)
   if vim.fn.has("nvim-0.10") == 1 then
     vim.api.nvim_set_option_value(name, value, { buf = bufnr })
   else
@@ -113,7 +113,7 @@ end
 ---@param winnr number
 ---@param name string
 ---@param value any
-function M.set_win_option(winnr, name, value)
+function M.win_set_option(winnr, name, value)
   if vim.fn.has("nvim-0.10") == 1 then
     vim.api.nvim_set_option_value(name, value, { win = winnr })
   else

--- a/lua/xcodebuild/helpers.lua
+++ b/lua/xcodebuild/helpers.lua
@@ -104,12 +104,12 @@ function M.update_readonly_buffer(bufnr, updateFoo)
     return
   end
 
-  vim.api.nvim_buf_set_option(bufnr, "readonly", false)
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
+  vim.api.nvim_set_option_value("readonly", false, { buf = bufnr })
+  vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
   updateFoo()
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
-  vim.api.nvim_buf_set_option(bufnr, "modified", false)
-  vim.api.nvim_buf_set_option(bufnr, "readonly", true)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+  vim.api.nvim_set_option_value("modified", false, { buf = bufnr })
+  vim.api.nvim_set_option_value("readonly", true, { buf = bufnr })
 end
 
 return M

--- a/lua/xcodebuild/helpers.lua
+++ b/lua/xcodebuild/helpers.lua
@@ -100,7 +100,7 @@ end
 ---@param bufnr number
 ---@param name string
 ---@param value any
-function M.nvim_buf_set_option_fwd_comp(bufnr, name, value)
+function M.set_buf_option(bufnr, name, value)
   if vim.fn.has("nvim-0.10") == 1 then
     vim.api.nvim_set_option_value(name, value, { buf = bufnr })
   else
@@ -110,14 +110,14 @@ end
 
 ---Wraps any nvim_win_set_option() call to ensure forward compatibility.
 ---The function is required because nvim_win_set_option() was deprecated in nvim-0.10.
----@param winID number
+---@param winnr number
 ---@param name string
 ---@param value any
-function M.nvim_win_set_option_fwd_comp(winID, name, value)
+function M.set_win_option(winnr, name, value)
   if vim.fn.has("nvim-0.10") == 1 then
-    vim.api.nvim_set_option_value(name, value, { win = winID })
+    vim.api.nvim_set_option_value(name, value, { win = winnr })
   else
-    vim.api.nvim_win_set_option(winID, name, value)
+    vim.api.nvim_win_set_option(winnr, name, value)
   end
 end
 
@@ -130,12 +130,12 @@ function M.update_readonly_buffer(bufnr, updateFoo)
     return
   end
 
-  M.nvim_buf_set_option_fwd_comp(bufnr, "readonly", false)
-  M.nvim_buf_set_option_fwd_comp(bufnr, "modifiable", true)
+  M.buf_set_option(bufnr, "readonly", false)
+  M.buf_set_option(bufnr, "modifiable", true)
   updateFoo()
-  M.nvim_buf_set_option_fwd_comp(bufnr, "modifiable", false)
-  M.nvim_buf_set_option_fwd_comp(bufnr, "modified", false)
-  M.nvim_buf_set_option_fwd_comp(bufnr, "readonly", true)
+  M.buf_set_option(bufnr, "modifiable", false)
+  M.buf_set_option(bufnr, "modified", false)
+  M.buf_set_option(bufnr, "readonly", true)
 end
 
 return M

--- a/lua/xcodebuild/tests/explorer.lua
+++ b/lua/xcodebuild/tests/explorer.lua
@@ -417,20 +417,20 @@ end
 ---Sets up the buffer for the test explorer.
 ---It also sets up the keymaps and the window options.
 local function setup_buffer()
-  vim.api.nvim_buf_set_option(M.bufnr, "modifiable", true)
+  vim.api.nvim_set_option_value("modifiable", true, { buf = M.bufnr })
 
-  vim.api.nvim_win_set_option(0, "fillchars", "eob: ")
-  vim.api.nvim_win_set_option(0, "wrap", false)
-  vim.api.nvim_win_set_option(0, "number", false)
-  vim.api.nvim_win_set_option(0, "relativenumber", false)
-  vim.api.nvim_win_set_option(0, "scl", "no")
-  vim.api.nvim_win_set_option(0, "spell", false)
+  vim.api.nvim_set_option_value("fillchars", "eob: ", { buf = 0 })
+  vim.api.nvim_set_option_value("wrap", false, { buf = 0 })
+  vim.api.nvim_set_option_value("number", false, { buf = 0 })
+  vim.api.nvim_set_option_value("relativenumber", false, { buf = 0 })
+  vim.api.nvim_set_option_value("scl", "no", { buf = 0 })
+  vim.api.nvim_set_option_value("spell", false, { buf = 0 })
 
-  vim.api.nvim_buf_set_option(M.bufnr, "filetype", "TestExplorer")
-  vim.api.nvim_buf_set_option(M.bufnr, "fileencoding", "utf-8")
-  vim.api.nvim_buf_set_option(M.bufnr, "modified", false)
-  vim.api.nvim_buf_set_option(M.bufnr, "readonly", false)
-  vim.api.nvim_buf_set_option(M.bufnr, "modifiable", false)
+  vim.api.nvim_set_option_value("filetype", "TestExplorer", { buf = M.bufnr })
+  vim.api.nvim_set_option_value("fileencoding", "utf-8", { buf = M.bufnr })
+  vim.api.nvim_set_option_value("modified", false, { buf = M.bufnr })
+  vim.api.nvim_set_option_value("readonly", false, { buf = M.bufnr })
+  vim.api.nvim_set_option_value("modifiable", false, { buf = M.bufnr })
 
   vim.api.nvim_buf_set_keymap(M.bufnr, "n", "q", "<cmd>close<cr>", {})
   vim.api.nvim_buf_set_keymap(M.bufnr, "n", "t", "", { callback = M.run_selected_tests, nowait = true })

--- a/lua/xcodebuild/tests/explorer.lua
+++ b/lua/xcodebuild/tests/explorer.lua
@@ -417,20 +417,20 @@ end
 ---Sets up the buffer for the test explorer.
 ---It also sets up the keymaps and the window options.
 local function setup_buffer()
-  vim.api.nvim_set_option_value("modifiable", true, { buf = M.bufnr })
+  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "modifiable", true, false)
 
-  vim.api.nvim_set_option_value("fillchars", "eob: ", { buf = 0 })
-  vim.api.nvim_set_option_value("wrap", false, { buf = 0 })
-  vim.api.nvim_set_option_value("number", false, { buf = 0 })
-  vim.api.nvim_set_option_value("relativenumber", false, { buf = 0 })
-  vim.api.nvim_set_option_value("scl", "no", { buf = 0 })
-  vim.api.nvim_set_option_value("spell", false, { buf = 0 })
+  helpers.nvim_win_set_option(0, "fillchars", "eob: ", true)
+  helpers.nvim_win_set_option(0, "wrap", false, true)
+  helpers.nvim_win_set_option(0, "number", false, true)
+  helpers.nvim_win_set_option(0, "relativenumber", false, true)
+  helpers.nvim_win_set_option(0, "scl", "no", true)
+  helpers.nvim_win_set_option(0, "spell", false, true)
 
-  vim.api.nvim_set_option_value("filetype", "TestExplorer", { buf = M.bufnr })
-  vim.api.nvim_set_option_value("fileencoding", "utf-8", { buf = M.bufnr })
-  vim.api.nvim_set_option_value("modified", false, { buf = M.bufnr })
-  vim.api.nvim_set_option_value("readonly", false, { buf = M.bufnr })
-  vim.api.nvim_set_option_value("modifiable", false, { buf = M.bufnr })
+  helpers.nvim_buf_set_option(M.bufnr, "filetype", "TestExplorer", false)
+  helpers.nvim_buf_set_option(M.bufnr, "fileencoding", "utf-8", false)
+  helpers.nvim_buf_set_option(M.bufnr, "modified", false, false)
+  helpers.nvim_buf_set_option(M.bufnr, "readonly", false, false)
+  helpers.nvim_buf_set_option(M.bufnr, "modifiable", false, false)
 
   vim.api.nvim_buf_set_keymap(M.bufnr, "n", "q", "<cmd>close<cr>", {})
   vim.api.nvim_buf_set_keymap(M.bufnr, "n", "t", "", { callback = M.run_selected_tests, nowait = true })

--- a/lua/xcodebuild/tests/explorer.lua
+++ b/lua/xcodebuild/tests/explorer.lua
@@ -417,20 +417,20 @@ end
 ---Sets up the buffer for the test explorer.
 ---It also sets up the keymaps and the window options.
 local function setup_buffer()
-  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "modifiable", true, false)
+  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "modifiable", true)
 
-  helpers.nvim_win_set_option(0, "fillchars", "eob: ", true)
-  helpers.nvim_win_set_option(0, "wrap", false, true)
-  helpers.nvim_win_set_option(0, "number", false, true)
-  helpers.nvim_win_set_option(0, "relativenumber", false, true)
-  helpers.nvim_win_set_option(0, "scl", "no", true)
-  helpers.nvim_win_set_option(0, "spell", false, true)
+  helpers.nvim_win_set_option_fwd_comp(0, "fillchars", "eob: ")
+  helpers.nvim_win_set_option_fwd_comp(0, "wrap", false)
+  helpers.nvim_win_set_option_fwd_comp(0, "number", false)
+  helpers.nvim_win_set_option_fwd_comp(0, "relativenumber", false)
+  helpers.nvim_win_set_option_fwd_comp(0, "scl", "no")
+  helpers.nvim_win_set_option_fwd_comp(0, "spell", false)
 
-  helpers.nvim_buf_set_option(M.bufnr, "filetype", "TestExplorer", false)
-  helpers.nvim_buf_set_option(M.bufnr, "fileencoding", "utf-8", false)
-  helpers.nvim_buf_set_option(M.bufnr, "modified", false, false)
-  helpers.nvim_buf_set_option(M.bufnr, "readonly", false, false)
-  helpers.nvim_buf_set_option(M.bufnr, "modifiable", false, false)
+  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "filetype", "TestExplorer")
+  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "fileencoding", "utf-8")
+  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "modified", false)
+  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "readonly", false)
+  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "modifiable", false)
 
   vim.api.nvim_buf_set_keymap(M.bufnr, "n", "q", "<cmd>close<cr>", {})
   vim.api.nvim_buf_set_keymap(M.bufnr, "n", "t", "", { callback = M.run_selected_tests, nowait = true })

--- a/lua/xcodebuild/tests/explorer.lua
+++ b/lua/xcodebuild/tests/explorer.lua
@@ -417,20 +417,20 @@ end
 ---Sets up the buffer for the test explorer.
 ---It also sets up the keymaps and the window options.
 local function setup_buffer()
-  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "modifiable", true)
+  helpers.buf_set_option(M.bufnr, "modifiable", true)
 
-  helpers.nvim_win_set_option_fwd_comp(0, "fillchars", "eob: ")
-  helpers.nvim_win_set_option_fwd_comp(0, "wrap", false)
-  helpers.nvim_win_set_option_fwd_comp(0, "number", false)
-  helpers.nvim_win_set_option_fwd_comp(0, "relativenumber", false)
-  helpers.nvim_win_set_option_fwd_comp(0, "scl", "no")
-  helpers.nvim_win_set_option_fwd_comp(0, "spell", false)
+  helpers.win_set_option(0, "fillchars", "eob: ")
+  helpers.win_set_option(0, "wrap", false)
+  helpers.win_set_option(0, "number", false)
+  helpers.win_set_option(0, "relativenumber", false)
+  helpers.win_set_option(0, "scl", "no")
+  helpers.win_set_option(0, "spell", false)
 
-  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "filetype", "TestExplorer")
-  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "fileencoding", "utf-8")
-  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "modified", false)
-  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "readonly", false)
-  helpers.nvim_buf_set_option_fwd_comp(M.bufnr, "modifiable", false)
+  helpers.buf_set_option(M.bufnr, "filetype", "TestExplorer")
+  helpers.buf_set_option(M.bufnr, "fileencoding", "utf-8")
+  helpers.buf_set_option(M.bufnr, "modified", false)
+  helpers.buf_set_option(M.bufnr, "readonly", false)
+  helpers.buf_set_option(M.bufnr, "modifiable", false)
 
   vim.api.nvim_buf_set_keymap(M.bufnr, "n", "q", "<cmd>close<cr>", {})
   vim.api.nvim_buf_set_keymap(M.bufnr, "n", "t", "", { callback = M.run_selected_tests, nowait = true })

--- a/lua/xcodebuild/xcode_logs/panel.lua
+++ b/lua/xcodebuild/xcode_logs/panel.lua
@@ -379,16 +379,16 @@ function M.setup_buffer(bufnr)
     vim.api.nvim_win_set_option(win[1], "spell", false)
   end
 
-  vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
-  vim.api.nvim_set_option_value("readonly", false, { buf = bufnr })
+  helpers.nvim_buf_set_option(bufnr, "modifiable", true, false)
+  helpers.nvim_buf_set_option(bufnr, "readonly", false, false)
 
-  vim.api.nvim_set_option_value("filetype", config.filetype, { buf = bufnr })
-  vim.api.nvim_set_option_value("buflisted", false, { buf = bufnr })
-  vim.api.nvim_set_option_value("fileencoding", "utf-8", { buf = bufnr })
-  vim.api.nvim_set_option_value("modified", false, { buf = bufnr })
+  helpers.nvim_buf_set_option(bufnr, "filetype", config.filetype, false)
+  helpers.nvim_buf_set_option(bufnr, "buflisted", false, false)
+  helpers.nvim_buf_set_option(bufnr, "fileencoding", "utf-8", false)
+  helpers.nvim_buf_set_option(bufnr, "modified", false, false)
 
-  vim.api.nvim_set_option_value("readonly", true, { buf = bufnr })
-  vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
+  helpers.nvim_buf_set_option(bufnr, "readonly", true, false)
+  helpers.nvim_buf_set_option(bufnr, "modifiable", false, false)
 
   vim.api.nvim_buf_set_keymap(bufnr, "n", "q", "<cmd>close<cr>", {})
   vim.api.nvim_buf_set_keymap(bufnr, "n", "o", "", {

--- a/lua/xcodebuild/xcode_logs/panel.lua
+++ b/lua/xcodebuild/xcode_logs/panel.lua
@@ -379,16 +379,16 @@ function M.setup_buffer(bufnr)
     vim.api.nvim_win_set_option(win[1], "spell", false)
   end
 
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
-  vim.api.nvim_buf_set_option(bufnr, "readonly", false)
+  vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
+  vim.api.nvim_set_option_value("readonly", false, { buf = bufnr })
 
-  vim.api.nvim_buf_set_option(bufnr, "filetype", config.filetype)
-  vim.api.nvim_buf_set_option(bufnr, "buflisted", false)
-  vim.api.nvim_buf_set_option(bufnr, "fileencoding", "utf-8")
-  vim.api.nvim_buf_set_option(bufnr, "modified", false)
+  vim.api.nvim_set_option_value("filetype", config.filetype, { buf = bufnr })
+  vim.api.nvim_set_option_value("buflisted", false, { buf = bufnr })
+  vim.api.nvim_set_option_value("fileencoding", "utf-8", { buf = bufnr })
+  vim.api.nvim_set_option_value("modified", false, { buf = bufnr })
 
-  vim.api.nvim_buf_set_option(bufnr, "readonly", true)
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+  vim.api.nvim_set_option_value("readonly", true, { buf = bufnr })
+  vim.api.nvim_set_option_value("modifiable", false, { buf = bufnr })
 
   vim.api.nvim_buf_set_keymap(bufnr, "n", "q", "<cmd>close<cr>", {})
   vim.api.nvim_buf_set_keymap(bufnr, "n", "o", "", {

--- a/lua/xcodebuild/xcode_logs/panel.lua
+++ b/lua/xcodebuild/xcode_logs/panel.lua
@@ -379,16 +379,16 @@ function M.setup_buffer(bufnr)
     vim.api.nvim_win_set_option(win[1], "spell", false)
   end
 
-  helpers.nvim_buf_set_option_fwd_comp(bufnr, "modifiable", true)
-  helpers.nvim_buf_set_option_fwd_comp(bufnr, "readonly", false)
+  helpers.buf_set_option(bufnr, "modifiable", true)
+  helpers.buf_set_option(bufnr, "readonly", false)
 
-  helpers.nvim_buf_set_option_fwd_comp(bufnr, "filetype", config.filetype)
-  helpers.nvim_buf_set_option_fwd_comp(bufnr, "buflisted", false)
-  helpers.nvim_buf_set_option_fwd_comp(bufnr, "fileencoding", "utf-8")
-  helpers.nvim_buf_set_option_fwd_comp(bufnr, "modified", false)
+  helpers.buf_set_option(bufnr, "filetype", config.filetype)
+  helpers.buf_set_option(bufnr, "buflisted", false)
+  helpers.buf_set_option(bufnr, "fileencoding", "utf-8")
+  helpers.buf_set_option(bufnr, "modified", false)
 
-  helpers.nvim_buf_set_option_fwd_comp(bufnr, "readonly", true)
-  helpers.nvim_buf_set_option_fwd_comp(bufnr, "modifiable", false)
+  helpers.buf_set_option(bufnr, "readonly", true)
+  helpers.buf_set_option(bufnr, "modifiable", false)
 
   vim.api.nvim_buf_set_keymap(bufnr, "n", "q", "<cmd>close<cr>", {})
   vim.api.nvim_buf_set_keymap(bufnr, "n", "o", "", {

--- a/lua/xcodebuild/xcode_logs/panel.lua
+++ b/lua/xcodebuild/xcode_logs/panel.lua
@@ -375,8 +375,8 @@ function M.setup_buffer(bufnr)
   local win = vim.fn.win_findbuf(bufnr)
 
   if win and win[1] then
-    vim.api.nvim_win_set_option(win[1], "wrap", false)
-    vim.api.nvim_win_set_option(win[1], "spell", false)
+    helpers.win_set_option(win[1], "wrap", false)
+    helpers.win_set_option(win[1], "spell", false)
   end
 
   helpers.buf_set_option(bufnr, "modifiable", true)

--- a/lua/xcodebuild/xcode_logs/panel.lua
+++ b/lua/xcodebuild/xcode_logs/panel.lua
@@ -379,16 +379,16 @@ function M.setup_buffer(bufnr)
     vim.api.nvim_win_set_option(win[1], "spell", false)
   end
 
-  helpers.nvim_buf_set_option(bufnr, "modifiable", true, false)
-  helpers.nvim_buf_set_option(bufnr, "readonly", false, false)
+  helpers.nvim_buf_set_option_fwd_comp(bufnr, "modifiable", true)
+  helpers.nvim_buf_set_option_fwd_comp(bufnr, "readonly", false)
 
-  helpers.nvim_buf_set_option(bufnr, "filetype", config.filetype, false)
-  helpers.nvim_buf_set_option(bufnr, "buflisted", false, false)
-  helpers.nvim_buf_set_option(bufnr, "fileencoding", "utf-8", false)
-  helpers.nvim_buf_set_option(bufnr, "modified", false, false)
+  helpers.nvim_buf_set_option_fwd_comp(bufnr, "filetype", config.filetype)
+  helpers.nvim_buf_set_option_fwd_comp(bufnr, "buflisted", false)
+  helpers.nvim_buf_set_option_fwd_comp(bufnr, "fileencoding", "utf-8")
+  helpers.nvim_buf_set_option_fwd_comp(bufnr, "modified", false)
 
-  helpers.nvim_buf_set_option(bufnr, "readonly", true, false)
-  helpers.nvim_buf_set_option(bufnr, "modifiable", false, false)
+  helpers.nvim_buf_set_option_fwd_comp(bufnr, "readonly", true)
+  helpers.nvim_buf_set_option_fwd_comp(bufnr, "modifiable", false)
 
   vim.api.nvim_buf_set_keymap(bufnr, "n", "q", "<cmd>close<cr>", {})
   vim.api.nvim_buf_set_keymap(bufnr, "n", "o", "", {


### PR DESCRIPTION
I'm currently getting the following error when trying to rebuild a project where xcodebuild isn't able to clear the logs

```
...lazy/xcodebuild.nvim/lua/xcodebuild/xcode_logs/panel.lua:246: Buffer is not 'modifiable'
stack traceback:
^I[C]: in function 'nvim_buf_set_lines'
^I...lazy/xcodebuild.nvim/lua/xcodebuild/xcode_logs/panel.lua:246: in function 'updateFoo'
^I...are/nvim/lazy/xcodebuild.nvim/lua/xcodebuild/helpers.lua:109: in function 'update_readonly_buffer'
^I...lazy/xcodebuild.nvim/lua/xcodebuild/xcode_logs/panel.lua:245: in function 'clear'
^I...azy/xcodebuild.nvim/lua/xcodebuild/xcode_logs/parser.lua:519: in function 'parse_logs'
^I.../lazy/xcodebuild.nvim/lua/xcodebuild/project/builder.lua:69: in function <.../lazy/xcodebuild.nvim/lua/xcodebuild/project/b
uilder.lua:68>
```

Since `nvim_buf_set_option()` was deprecated in nvim 0.10 - see https://neovim.io/doc/user/deprecated.html - I thought that was the cause. Turns out it wasn't/or it wasn't the only one.

Any thoughts?