### PR TITLE
feat: boot simulator if app fails to install due to simulator state 149

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -1244,12 +1244,13 @@ M.install_app_on_device({destination}, {appPath}, {callback})
 
 
                                 *xcodebuild.core.xcode.install_app_on_simulator*
-M.install_app_on_simulator({destination}, {appPath}, {callback})
+M.install_app_on_simulator({destination}, {appPath}, {retrying}, {callback})
   Installs the application on simulator.
 
   Parameters: ~
     {destination}  (string)
     {appPath}      (string)
+    {retrying}     (boolean|nil)
     {callback}     (function|nil)
 
   Returns: ~
@@ -1300,12 +1301,13 @@ M.launch_app({platform}, {destination}, {bundleId}, {waitForDebugger}, {callback
 
 
                                           *xcodebuild.core.xcode.boot_simulator*
-M.boot_simulator({destination}, {callback})
+M.boot_simulator({destination}, {callback}, {onError})
   Boots the simulator and launches the Simulator app if needed.
 
   Parameters: ~
     {destination}  (string)
     {callback}     (function|nil)
+    {onError}      (function|nil)
 
   Returns: ~
     (number)   job id

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -1244,14 +1244,14 @@ M.install_app_on_device({destination}, {appPath}, {callback})
 
 
                                 *xcodebuild.core.xcode.install_app_on_simulator*
-M.install_app_on_simulator({destination}, {appPath}, {retrying}, {callback})
+M.install_app_on_simulator({destination}, {appPath}, {bootIfNeeded}, {callback})
   Installs the application on simulator.
 
   Parameters: ~
-    {destination}  (string)
-    {appPath}      (string)
-    {retrying}     (boolean|nil)
-    {callback}     (function|nil)
+    {destination}   (string)
+    {appPath}       (string)
+    {bootIfNeeded}  (boolean|nil)
+    {callback}      (function|nil)
 
   Returns: ~
     (number)   job id
@@ -1301,13 +1301,12 @@ M.launch_app({platform}, {destination}, {bundleId}, {waitForDebugger}, {callback
 
 
                                           *xcodebuild.core.xcode.boot_simulator*
-M.boot_simulator({destination}, {callback}, {onError})
+M.boot_simulator({destination}, {callback})
   Boots the simulator and launches the Simulator app if needed.
 
   Parameters: ~
     {destination}  (string)
-    {callback}     (function|nil)
-    {onError}      (function|nil)
+    {callback}     (fun(success:boolean)|nil)
 
   Returns: ~
     (number)   job id

--- a/lua/xcodebuild/core/xcode.lua
+++ b/lua/xcodebuild/core/xcode.lua
@@ -527,7 +527,7 @@ function M.install_app_on_simulator(destination, appPath, retrying, callback)
             util.call(callback)
           else
             local retry = function()
-              M.install_app_on_simulator(destination, appPath, retrying, callback)
+              M.install_app_on_simulator(destination, appPath, true, callback)
             end
 
             M.boot_simulator(destination, retry, function()

--- a/lua/xcodebuild/integrations/quick.lua
+++ b/lua/xcodebuild/integrations/quick.lua
@@ -72,24 +72,48 @@ local function parse_test_file(bufnr)
 ]]
   )
 
-  for _, match in quickQueries:iter_matches(root, bufnr) do
-    local capturedNodes = {}
+  if vim.fn.has("nvim-0.11") == 1 then
+    for _, match, _ in quickQueries:iter_matches(root, bufnr) do
+      local capturedNodes = {}
 
-    for i, capture in ipairs(quickQueries.captures) do
-      local currentMatch = match[i]
+      for id, nodes in pairs(match) do
+        local capture = quickQueries.captures[id]
 
-      if currentMatch and capture ~= "quick-func" then
-        local startRow, _, endRow, _ = currentMatch:range()
-        table.insert(capturedNodes, {
-          id = capture,
-          name = not capture:match("definition") and ts.get_node_text(currentMatch, bufnr) or nil,
-          row = startRow,
-          endRow = endRow,
-        })
+        if capture ~= "quick-func" then
+          for _, currentMatch in ipairs(nodes) do
+            local startRow, _, endRow, _ = currentMatch:range()
+            table.insert(capturedNodes, {
+              id = capture,
+              name = not capture:match("definition") and ts.get_node_text(currentMatch, bufnr) or nil,
+              row = startRow,
+              endRow = endRow,
+            })
+          end
+        end
       end
-    end
 
-    table.insert(result, capturedNodes)
+      table.insert(result, capturedNodes)
+    end
+  else
+    for _, match in quickQueries:iter_matches(root, bufnr) do
+      local capturedNodes = {}
+
+      for i, capture in ipairs(quickQueries.captures) do
+        local currentMatch = match[i]
+
+        if currentMatch and capture ~= "quick-func" then
+          local startRow, _, endRow, _ = currentMatch:range()
+          table.insert(capturedNodes, {
+            id = capture,
+            name = not capture:match("definition") and ts.get_node_text(currentMatch, bufnr) or nil,
+            row = startRow,
+            endRow = endRow,
+          })
+        end
+      end
+
+      table.insert(result, capturedNodes)
+    end
   end
 
   return result

--- a/specs/quick_spec.lua
+++ b/specs/quick_spec.lua
@@ -12,7 +12,7 @@ local function mock(id)
   local testsContent = vim.fn.readfile(cwd .. "/specs/quick_test_data/quick_test_" .. id .. ".swift")
   local text = table.concat(testsContent, "\n")
 
-  vim.treesitter.get_parser = function(_, _)
+  vim.treesitter.get_parser = function(_, _, _)
     local parser = vim.treesitter.get_string_parser(text, "swift")
     return parser
   end


### PR DESCRIPTION
When building and running, sometimes the simulator may not be on a `booted` state, and thus the script will fail without trying to boot. This applies a retry functionality to boot the simulator prior to install.