### PR TITLE
xcode-build-server's config --skip-validate-bin flag support

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -888,6 +888,9 @@ M.run_failing_tests()                     *xcodebuild.actions.run_failing_tests*
   @deprecated use `rerun_failed_tests` instead
 
 
+M.toggle_bin_validation()             *xcodebuild.actions.toggle_bin_validation*
+
+
 ==============================================================================
 Constants                                                 *xcodebuild.constants*
 
@@ -1622,20 +1625,21 @@ so the settings can be loaded.
 ProjectSettings
 
   Fields: ~
-    {deviceName}      (string|nil) device name (ex. "iPhone 12")
-    {os}              (string|nil) OS version (ex. "14.5")
-    {platform}        (PlatformId|nil) platform (ex. "iOS")
-    {projectFile}     (string|nil) project file path (ex. "path/to/Project.xcodeproj")
-    {projectCommand}  (string|nil) project command (ex. "-project 'path/to/Project.xcodeproj'" or "-workspace 'path/to/Project.xcworkspace'")
-    {scheme}          (string|nil) scheme name (ex. "MyApp")
-    {destination}     (string|nil) destination (ex. "28B52DAA-BC2F-410B-A5BE-F485A3AFB0BC")
-    {bundleId}        (string|nil) bundle identifier (ex. "com.mycompany.myapp")
-    {appPath}         (string|nil) app path (ex. "path/to/MyApp.app")
-    {productName}     (string|nil) product name (ex. "MyApp")
-    {testPlan}        (string|nil) test plan name (ex. "MyAppTests")
-    {xcodeproj}       (string|nil) xcodeproj file path (ex. "path/to/Project.xcodeproj")
-    {lastBuildTime}   (number|nil) last build time in seconds
-    {showCoverage}    (boolean|nil) if the inline code coverage should be shown
+    {deviceName}       (string|nil) device name (ex. "iPhone 12")
+    {os}               (string|nil) OS version (ex. "14.5")
+    {platform}         (PlatformId|nil) platform (ex. "iOS")
+    {projectFile}      (string|nil) project file path (ex. "path/to/Project.xcodeproj")
+    {projectCommand}   (string|nil) project command (ex. "-project 'path/to/Project.xcodeproj'" or "-workspace 'path/to/Project.xcworkspace'")
+    {scheme}           (string|nil) scheme name (ex. "MyApp")
+    {destination}      (string|nil) destination (ex. "28B52DAA-BC2F-410B-A5BE-F485A3AFB0BC")
+    {bundleId}         (string|nil) bundle identifier (ex. "com.mycompany.myapp")
+    {appPath}          (string|nil) app path (ex. "path/to/MyApp.app")
+    {productName}      (string|nil) product name (ex. "MyApp")
+    {testPlan}         (string|nil) test plan name (ex. "MyAppTests")
+    {xcodeproj}        (string|nil) xcodeproj file path (ex. "path/to/Project.xcodeproj")
+    {lastBuildTime}    (number|nil) last build time in seconds
+    {showCoverage}     (boolean|nil) if the inline code coverage should be shown
+    {skipValidateBin}  (boolean|nil) if xcode-build-server should skip bin validation
 
 
 M.settings                                  *xcodebuild.project.config.settings*
@@ -3708,16 +3712,13 @@ M.is_enabled()
     (boolean)
 
 
-                         *xcodebuild.integrations.xcode-build-server.run_config*
-M.run_config({projectCommand}, {scheme})
-  Calls "config" command of xcode-build-server in order to update buildServer.json file.
+              *xcodebuild.integrations.xcode-build-server.toggle_bin_validation*
+M.toggle_bin_validation()
 
-  Parameters: ~
-    {projectCommand}  (string) either "-project 'path/to/project.xcodeproj'" or "-workspace 'path/to/workspace.xcworkspace'"
-    {scheme}          (string)
 
-  Returns: ~
-    (number)   job id
+                      *xcodebuild.integrations.xcode-build-server.update_config*
+M.update_config()
+  Updates xcode-build-server config if needed.
 
 
 ==============================================================================

--- a/lua/xcodebuild/actions.lua
+++ b/lua/xcodebuild/actions.lua
@@ -21,6 +21,7 @@ local projectBuilder = require("xcodebuild.project.builder")
 local projectConfig = require("xcodebuild.project.config")
 local projectManager = require("xcodebuild.project.manager")
 local lsp = require("xcodebuild.integrations.lsp")
+local xcodeBuildServer = require("xcodebuild.integrations.xcode-build-server")
 
 local M = {}
 
@@ -392,6 +393,14 @@ end
 ---@deprecated use `rerun_failed_tests` instead
 function M.run_failing_tests()
   M.rerun_failed_tests()
+end
+
+-- Xcode Build Server
+
+-- Toggles whether --skip-validate-bin flag is passed
+-- to xcode-build-server's config command or not.
+function M.toggle_bin_validation()
+  xcodeBuildServer.toggle_bin_validation()
 end
 
 return M

--- a/lua/xcodebuild/init.lua
+++ b/lua/xcodebuild/init.lua
@@ -314,6 +314,7 @@ function M.setup(options)
   vim.api.nvim_create_user_command("XcodebuildOpenInXcode", call(actions.open_in_xcode), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildQuickfixLine", call(actions.quickfix_line), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildCodeActions", call(actions.show_code_actions), { nargs = 0 })
+  vim.api.nvim_create_user_command("XcodebuildToggleBinValidation", call(actions.toggle_bin_validation), { nargs = 0 })
 
   -- Backward compatibility
   vim.api.nvim_create_user_command("XcodebuildTestFunc", function()

--- a/lua/xcodebuild/integrations/xcode-build-server.lua
+++ b/lua/xcodebuild/integrations/xcode-build-server.lua
@@ -7,6 +7,7 @@
 ---@brief ]]
 
 local config = require("xcodebuild.core.config").options.integrations.xcode_build_server
+local projectConfig = require("xcodebuild.project.config")
 
 local M = {}
 
@@ -22,12 +23,46 @@ function M.is_enabled()
   return config.enabled
 end
 
+-- Toggles whether --skip-validate-bin flag is
+-- passed to xcode-build-server's config command
+-- and updates config if needed.
+function M.toggle_bin_validation()
+  if projectConfig.settings.validateBin == nil then
+    projectConfig.settings.skipValidateBin = true
+  else
+    projectConfig.settings.skipValidateBin = not projectConfig.settings.skipValidateBin
+  end
+
+  projectConfig.save_settings()
+  M.update_config()
+end
+
+---Updates xcode-build-server config if needed.
+function M.update_config()
+   if not M.is_enabled() or not M.is_installed() then
+    return
+  end
+
+  local projectCommand = projectConfig.settings.projectCommand
+  local scheme = projectConfig.settings.scheme
+
+  if projectCommand and scheme then
+    run_config(projectCommand, scheme)
+  end
+end
+
 ---Calls "config" command of xcode-build-server in order to update buildServer.json file.
 ---@param projectCommand string either "-project 'path/to/project.xcodeproj'" or "-workspace 'path/to/workspace.xcworkspace'"
 ---@param scheme string
 ---@return number # job id
-function M.run_config(projectCommand, scheme)
-  return vim.fn.jobstart("xcode-build-server config " .. projectCommand .. " -scheme '" .. scheme .. "'", {
+function run_config(projectCommand, scheme)
+  local cmd = "xcode-build-server config " .. projectCommand .. " -scheme '" .. scheme .. "'"
+
+  if (projectConfig.settings.skipValidateBin or false) then
+    cmd = cmd .. " --skip-validate-bin"
+  end
+  
+  return vim.fn.jobstart(cmd, {
     on_exit = function()
       require("xcodebuild.integrations.lsp").restart_sourcekit_lsp()
     end,

--- a/lua/xcodebuild/project/config.lua
+++ b/lua/xcodebuild/project/config.lua
@@ -23,6 +23,7 @@
 ---@field xcodeproj string|nil xcodeproj file path (ex. "path/to/Project.xcodeproj")
 ---@field lastBuildTime number|nil last build time in seconds
 ---@field showCoverage boolean|nil if the inline code coverage should be shown
+---@field skipValidateBin boolean|nil if xcode-build-server should skip bin validation 
 
 local M = {}
 

--- a/lua/xcodebuild/ui/pickers.lua
+++ b/lua/xcodebuild/ui/pickers.lua
@@ -48,17 +48,7 @@ local progressFrames = {
 ---Updates xcode-build-server config if needed.
 local function update_xcode_build_server_config()
   local xcodeBuildServer = require("xcodebuild.integrations.xcode-build-server")
-
-  if not xcodeBuildServer.is_enabled() or not xcodeBuildServer.is_installed() then
-    return
-  end
-
-  local projectCommand = projectConfig.settings.projectCommand
-  local scheme = projectConfig.settings.scheme
-
-  if projectCommand and scheme then
-    xcodeBuildServer.run_config(projectCommand, scheme)
-  end
+  xcodeBuildServer.update_config()
 end
 
 ---Stops the spinner animation.
@@ -523,6 +513,8 @@ function M.show_all_actions()
     "Install Application",
     "Uninstall Application",
     "---------------------------------",
+    "Toggle Bin Validation",
+    "---------------------------------",
     "Clean DerivedData",
     "Open Project in Xcode",
   }
@@ -564,6 +556,10 @@ function M.show_all_actions()
     actions.boot_simulator,
     actions.install_app,
     actions.uninstall_app,
+
+    function() end,
+
+    actions.toggle_bin_validation,
 
     function() end,
 


### PR DESCRIPTION
Added an ability to toggle whether --skip-validate-bin flag is passed to xcode-build-server's config command whenever project's scheme is changed. It is required for code auto-completion to work in cases when custom swift compiler is used.

From issue
https://github.com/wojciech-kulik/xcodebuild.nvim/issues/162