### PR TITLE
feat: add lldbPath option to xcodebuild.integrations.dap.setup

### DIFF
--- a/lua/xcodebuild/integrations/dap.lua
+++ b/lua/xcodebuild/integrations/dap.lua
@@ -536,10 +536,11 @@ end
 ---{loadBreakpoints} - if true or nil, sets up an autocmd to load breakpoints when a Swift file is opened.
 ---@param codelldbPath string
 ---@param loadBreakpoints boolean|nil default: true
-function M.setup(codelldbPath, loadBreakpoints)
+---@param lldbPath string|nil default: nil
+function M.setup(codelldbPath, loadBreakpoints, lldbPath)
   local dap = require("dap")
   dap.configurations.swift = M.get_swift_configuration()
-  dap.adapters.codelldb = M.get_codelldb_adapter(codelldbPath)
+  dap.adapters.codelldb = M.get_codelldb_adapter(codelldbPath, lldbPath)
 
   if loadBreakpoints ~= false then
     vim.api.nvim_create_autocmd({ "BufReadPost" }, {


### PR DESCRIPTION
This PR adds lldbPath option to `require('xcodebuild.integrations.dap').setup()`.

```lua
local xcodebuild = require('xcodebuild.integrations.dap')
xcodebuild.setup(".../codelldb", ".../Xcode.app/.../LLDB.framework/.../LLDB") -- LLDB Library Path
```

I wrote this because I ran into some problem with codelldb DAP where the debugger pauses the application endlessly, makes it impossible to debug. (I will report the issue later, since right now I am not sure what is causing this, and changing LLDB library path didn't help.)