### PR TITLE
Added an option to automaticaly search for a non-configured project for oil, nvim-tree and neo-tree integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ vim.keymap.set("n", "<leader>xa", "<cmd>XcodebuildCodeActions<cr>", { desc = "Sh
     nvim_tree = {
       enabled = true, -- enable updating Xcode project files when using nvim-tree
       guess_target = true, -- guess target for the new file based on the file path
+      find_xcodeproj = false, -- instead of using configured xcodeproj search for xcodeproj closest to targeted file
       should_update_project = function(path) -- path can lead to directory or file
         -- it could be useful if you mix Xcode project with SPM for example
         return true
@@ -422,6 +423,7 @@ vim.keymap.set("n", "<leader>xa", "<cmd>XcodebuildCodeActions<cr>", { desc = "Sh
     neo_tree = {
       enabled = true, -- enable updating Xcode project files when using neo-tree.nvim
       guess_target = true, -- guess target for the new file based on the file path
+      find_xcodeproj = false, -- instead of using configured xcodeproj search for xcodeproj closest to targeted file
       should_update_project = function(path) -- path can lead to directory or file
         -- it could be useful if you mix Xcode project with SPM for example
         return true
@@ -430,6 +432,7 @@ vim.keymap.set("n", "<leader>xa", "<cmd>XcodebuildCodeActions<cr>", { desc = "Sh
     oil_nvim = {
       enabled = true, -- enable updating Xcode project files when using oil.nvim
       guess_target = true, -- guess target for the new file based on the file path
+      find_xcodeproj = false, -- instead of using configured xcodeproj search for xcodeproj closest to targeted file
       should_update_project = function(path) -- path can lead to directory or file
         -- it could be useful if you mix Xcode project with SPM for example
         return true

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -1882,13 +1882,14 @@ M.create_new_file()
 
 
                                 *xcodebuild.project.manager.add_file_to_targets*
-M.add_file_to_targets({filepath}, {targets})
+M.add_file_to_targets({filepath}, {targets}, {findXcodeproj})
   Adds the file to the selected targets.
   The group from {filepath} must exist in the project.
 
   Parameters: ~
-    {filepath}  (string)
-    {targets}   (string[])
+    {filepath}       (string)
+    {targets}        (string[])
+    {findXcodeproj}  (boolean)
 
 
                                 *xcodebuild.project.manager.get_project_targets*
@@ -1924,13 +1925,14 @@ M.add_current_file()
 
 
                                           *xcodebuild.project.manager.move_file*
-M.move_file({oldFilePath}, {newFilePath})
+M.move_file({oldFilePath}, {newFilePath}, {findXcodeproj})
   Moves the file to the new path in the project.
   The group from {newFilePath} must exist in the project.
 
   Parameters: ~
-    {oldFilePath}  (string)
-    {newFilePath}  (string)
+    {oldFilePath}    (string)
+    {newFilePath}    (string)
+    {findXcodeproj}  (boolean)
 
 
                                         *xcodebuild.project.manager.rename_file*

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -1900,7 +1900,7 @@ M.get_project_targets()
 
 
                                            *xcodebuild.project.manager.add_file*
-M.add_file({filepath}, {callback}, {opts})
+M.add_file({filepath}, {callback}, {opts}, {find_xcodeproj})
   Adds the file to project.
   Asks the user to select the targets or tries to guess them.
 
@@ -1911,9 +1911,10 @@ M.add_file({filepath}, {callback}, {opts})
   Calls the {callback} after the file has been added to the targets or the user has canceled the action.
 
   Parameters: ~
-    {filepath}  (string)
-    {callback}  (function|nil)
-    {opts}      ({guessTarget:boolean,createGroups:boolean}|nil)
+    {filepath}        (string)
+    {callback}        (function|nil)
+    {opts}            ({guessTarget:boolean,createGroups:boolean}|nil)
+    {find_xcodeproj}  (boolean)
 
 
                                    *xcodebuild.project.manager.add_current_file*
@@ -1934,12 +1935,13 @@ M.move_file({oldFilePath}, {newFilePath})
 
 
                                         *xcodebuild.project.manager.rename_file*
-M.rename_file({oldFilePath}, {newFilePath})
+M.rename_file({oldFilePath}, {newFilePath}, {find_xcodeproj})
   Renames the file in the project.
 
   Parameters: ~
-    {oldFilePath}  (string)
-    {newFilePath}  (string)
+    {oldFilePath}     (string)
+    {newFilePath}     (string)
+    {find_xcodeproj}  (boolean)
 
 
                                 *xcodebuild.project.manager.rename_current_file*
@@ -1948,11 +1950,13 @@ M.rename_current_file()
   Asks the user for the new file name.
 
 
-M.delete_file({filepath})               *xcodebuild.project.manager.delete_file*
+                                        *xcodebuild.project.manager.delete_file*
+M.delete_file({filepath}, {find_xcodeproj})
   Deletes the file from the project.
 
   Parameters: ~
-    {filepath}  (string)
+    {filepath}        (string)
+    {find_xcodeproj}  (boolean)
 
 
                                 *xcodebuild.project.manager.delete_current_file*
@@ -1980,12 +1984,13 @@ M.add_current_group()
 
 
                                        *xcodebuild.project.manager.rename_group*
-M.rename_group({oldGroupPath}, {newGroupPath})
+M.rename_group({oldGroupPath}, {newGroupPath}, {find_xcodeproj})
   Renames the group in the project.
 
   Parameters: ~
-    {oldGroupPath}  (string)
-    {newGroupPath}  (string)
+    {oldGroupPath}    (string)
+    {newGroupPath}    (string)
+    {find_xcodeproj}  (boolean)
 
 
                                *xcodebuild.project.manager.rename_current_group*
@@ -1995,15 +2000,16 @@ M.rename_current_group()
 
 
                                *xcodebuild.project.manager.move_or_rename_group*
-M.move_or_rename_group({oldGroupPath}, {newGroupPath})
+M.move_or_rename_group({oldGroupPath}, {newGroupPath}, {find_xcodeproj})
   Moves or renames the group in the project.
   If the parent path is different, it moves the group.
   If the parent path is the same, it renames the group.
   The parent group of {newGroupPath} must exist.
 
   Parameters: ~
-    {oldGroupPath}  (string)
-    {newGroupPath}  (string)
+    {oldGroupPath}    (string)
+    {newGroupPath}    (string)
+    {find_xcodeproj}  (boolean)
 
 
 M.delete_group()                       *xcodebuild.project.manager.delete_group*

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -1900,7 +1900,7 @@ M.get_project_targets()
 
 
                                            *xcodebuild.project.manager.add_file*
-M.add_file({filepath}, {callback}, {opts}, {find_xcodeproj})
+M.add_file({filepath}, {callback}, {opts})
   Adds the file to project.
   Asks the user to select the targets or tries to guess them.
 
@@ -1911,10 +1911,9 @@ M.add_file({filepath}, {callback}, {opts}, {find_xcodeproj})
   Calls the {callback} after the file has been added to the targets or the user has canceled the action.
 
   Parameters: ~
-    {filepath}        (string)
-    {callback}        (function|nil)
-    {opts}            ({guessTarget:boolean,createGroups:boolean}|nil)
-    {find_xcodeproj}  (boolean)
+    {filepath}  (string)
+    {callback}  (function|nil)
+    {opts}      ({guessTarget:boolean,createGroups:boolean,findXcodeproj:boolean}|nil)
 
 
                                    *xcodebuild.project.manager.add_current_file*
@@ -1935,13 +1934,13 @@ M.move_file({oldFilePath}, {newFilePath})
 
 
                                         *xcodebuild.project.manager.rename_file*
-M.rename_file({oldFilePath}, {newFilePath}, {find_xcodeproj})
+M.rename_file({oldFilePath}, {newFilePath}, {findXcodeproj})
   Renames the file in the project.
 
   Parameters: ~
-    {oldFilePath}     (string)
-    {newFilePath}     (string)
-    {find_xcodeproj}  (boolean)
+    {oldFilePath}    (string)
+    {newFilePath}    (string)
+    {findXcodeproj}  (boolean)
 
 
                                 *xcodebuild.project.manager.rename_current_file*
@@ -1951,12 +1950,12 @@ M.rename_current_file()
 
 
                                         *xcodebuild.project.manager.delete_file*
-M.delete_file({filepath}, {find_xcodeproj})
+M.delete_file({filepath}, {findXcodeproj})
   Deletes the file from the project.
 
   Parameters: ~
-    {filepath}        (string)
-    {find_xcodeproj}  (boolean)
+    {filepath}       (string)
+    {findXcodeproj}  (boolean)
 
 
                                 *xcodebuild.project.manager.delete_current_file*
@@ -1971,12 +1970,12 @@ M.create_new_group()
   Asks the user for the group name.
 
 
-M.add_group({path}, {find_xcodeproj})     *xcodebuild.project.manager.add_group*
+M.add_group({path}, {findXcodeproj})      *xcodebuild.project.manager.add_group*
   Adds the group to the project.
 
   Parameters: ~
-    {path}            (string)
-    {find_xcodeproj}  (boolean)
+    {path}           (string)
+    {findXcodeproj}  (boolean)
 
 
                                   *xcodebuild.project.manager.add_current_group*
@@ -1985,13 +1984,13 @@ M.add_current_group()
 
 
                                        *xcodebuild.project.manager.rename_group*
-M.rename_group({oldGroupPath}, {newGroupPath}, {find_xcodeproj})
+M.rename_group({oldGroupPath}, {newGroupPath}, {findXcodeproj})
   Renames the group in the project.
 
   Parameters: ~
-    {oldGroupPath}    (string)
-    {newGroupPath}    (string)
-    {find_xcodeproj}  (boolean)
+    {oldGroupPath}   (string)
+    {newGroupPath}   (string)
+    {findXcodeproj}  (boolean)
 
 
                                *xcodebuild.project.manager.rename_current_group*
@@ -2001,16 +2000,16 @@ M.rename_current_group()
 
 
                                *xcodebuild.project.manager.move_or_rename_group*
-M.move_or_rename_group({oldGroupPath}, {newGroupPath}, {find_xcodeproj})
+M.move_or_rename_group({oldGroupPath}, {newGroupPath}, {findXcodeproj})
   Moves or renames the group in the project.
   If the parent path is different, it moves the group.
   If the parent path is the same, it renames the group.
   The parent group of {newGroupPath} must exist.
 
   Parameters: ~
-    {oldGroupPath}    (string)
-    {newGroupPath}    (string)
-    {find_xcodeproj}  (boolean)
+    {oldGroupPath}   (string)
+    {newGroupPath}   (string)
+    {findXcodeproj}  (boolean)
 
 
 M.delete_group()                       *xcodebuild.project.manager.delete_group*

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -1971,11 +1971,12 @@ M.create_new_group()
   Asks the user for the group name.
 
 
-M.add_group({path})                       *xcodebuild.project.manager.add_group*
+M.add_group({path}, {find_xcodeproj})     *xcodebuild.project.manager.add_group*
   Adds the group to the project.
 
   Parameters: ~
-    {path}  (string)
+    {path}            (string)
+    {find_xcodeproj}  (boolean)
 
 
                                   *xcodebuild.project.manager.add_current_group*

--- a/lua/xcodebuild/actions.lua
+++ b/lua/xcodebuild/actions.lua
@@ -308,7 +308,7 @@ end
 ---@param filepath string
 ---@param targets string[]
 function M.add_file_to_targets(filepath, targets)
-  projectManager.add_file_to_targets(filepath, targets)
+  projectManager.add_file_to_targets(filepath, targets, false)
 end
 
 ---Creates a new file and updates the project.

--- a/lua/xcodebuild/core/config.lua
+++ b/lua/xcodebuild/core/config.lua
@@ -108,6 +108,7 @@ local defaults = {
     nvim_tree = {
       enabled = true, -- enable updating Xcode project files when using nvim-tree
       guess_target = true, -- guess target for the new file based on the file path
+      find_xcodeproj = false, -- instead of using configured xcodeproj search for xcodeproj closest to targeted file
       should_update_project = function(path) -- path can lead to directory or file
         -- it could be useful if you mix Xcode project with SPM for example
         return true
@@ -116,6 +117,7 @@ local defaults = {
     neo_tree = {
       enabled = true, -- enable updating Xcode project files when using neo-tree.nvim
       guess_target = true, -- guess target for the new file based on the file path
+      find_xcodeproj = false, -- instead of using configured xcodeproj search for xcodeproj closest to targeted file
       should_update_project = function(path) -- path can lead to directory or file
         -- it could be useful if you mix Xcode project with SPM for example
         return true
@@ -124,6 +126,7 @@ local defaults = {
     oil_nvim = {
       enabled = true, -- enable updating Xcode project files when using oil.nvim
       guess_target = true, -- guess target for the file based on the file path
+      find_xcodeproj = false, -- instead of using configured xcodeproj search for xcodeproj closest to targeted file
       should_update_project = function(path) -- path can lead to directory or file
         -- it could be useful if you mix Xcode project with SPM for example
         return true

--- a/lua/xcodebuild/integrations/neo-tree.lua
+++ b/lua/xcodebuild/integrations/neo-tree.lua
@@ -52,9 +52,9 @@ function M.setup()
 
     local isDir = vim.fn.isdirectory(data.destination) == 1
     if isDir then
-      projectManager.move_or_rename_group(data.source, data.destination)
+      projectManager.move_or_rename_group(data.source, data.destination, config.find_xcodeproj)
     else
-      projectManager.move_file(data.source, data.destination)
+      projectManager.move_file(data.source, data.destination, config.find_xcodeproj)
     end
   end
 
@@ -67,12 +67,12 @@ function M.setup()
 
       local isDir = vim.fn.isdirectory(path) == 1
       if isDir then
-        projectManager.add_group(path)
+        projectManager.add_group(path, config.find_xcodeproj)
       else
         projectManager.add_file(path, nil, {
           guessTarget = config.guess_target,
           createGroups = true,
-        })
+        }, config.find_xcodeproj)
       end
     end,
   })
@@ -88,9 +88,9 @@ function M.setup()
       local isDir = extension == ""
 
       if isDir then
-        projectManager.delete_group(path)
+        projectManager.delete_group(path, config.find_xcodeproj)
       else
-        projectManager.delete_file(path)
+        projectManager.delete_file(path, config.find_xcodeproj)
       end
     end,
   })

--- a/lua/xcodebuild/integrations/neo-tree.lua
+++ b/lua/xcodebuild/integrations/neo-tree.lua
@@ -72,7 +72,8 @@ function M.setup()
         projectManager.add_file(path, nil, {
           guessTarget = config.guess_target,
           createGroups = true,
-        }, config.find_xcodeproj)
+          findXcodeproj = config.find_xcodeproj,
+        })
       end
     end,
   })

--- a/lua/xcodebuild/integrations/nvim-tree.lua
+++ b/lua/xcodebuild/integrations/nvim-tree.lua
@@ -50,16 +50,16 @@ function M.setup()
     if shouldUpdateProject(data.old_name) then
       local isDir = vim.fn.isdirectory(data.new_name) == 1
       if isDir then
-        projectManager.move_or_rename_group(data.old_name, data.new_name)
+        projectManager.move_or_rename_group(data.old_name, data.new_name, config.find_xcodeproj)
       else
-        projectManager.move_file(data.old_name, data.new_name)
+        projectManager.move_file(data.old_name, data.new_name, config.find_xcodeproj)
       end
     end
   end)
 
   api.events.subscribe(Event.FileRemoved, function(data)
     if shouldUpdateProject(data.fname) then
-      projectManager.delete_file(data.fname)
+      projectManager.delete_file(data.fname, config.find_xcodeproj)
     end
   end)
 
@@ -68,7 +68,7 @@ function M.setup()
       projectManager.add_file(data.fname, nil, {
         guessTarget = config.guess_target,
         createGroups = true,
-      })
+      }, config.find_xcodeproj)
     end
   end)
 
@@ -76,13 +76,13 @@ function M.setup()
     local isDir = vim.fn.isdirectory(data.folder_name) == 1
 
     if shouldUpdateProject(data.folder_name) and isDir then
-      projectManager.add_group(data.folder_name)
+      projectManager.add_group(data.folder_name, config.find_xcodeproj)
     end
   end)
 
   api.events.subscribe(Event.FolderRemoved, function(data)
     if shouldUpdateProject(data.folder_name) then
-      projectManager.delete_group(data.folder_name)
+      projectManager.delete_group(data.folder_name, config.find_xcodeproj)
     end
   end)
 end

--- a/lua/xcodebuild/integrations/nvim-tree.lua
+++ b/lua/xcodebuild/integrations/nvim-tree.lua
@@ -68,7 +68,8 @@ function M.setup()
       projectManager.add_file(data.fname, nil, {
         guessTarget = config.guess_target,
         createGroups = true,
-      }, config.find_xcodeproj)
+        findXcodeproj = config.find_xcodeproj,
+      })
     end
   end)
 

--- a/lua/xcodebuild/integrations/oil-nvim.lua
+++ b/lua/xcodebuild/integrations/oil-nvim.lua
@@ -111,14 +111,14 @@ function M.setup()
               end, {
                 guessTarget = config.guess_target,
                 createGroups = true,
-              })
+              }, config.find_xcodeproj)
             end)
             coroutine.yield()
           end
 
           if action.type == "create" then
             if action.entry_type == "directory" then
-              projectManager.add_group(path)
+              projectManager.add_group(path, config.find_xcodeproj)
             elseif action.entry_type == "file" then
               addFileAndWaitForTargetSelection(path)
             end
@@ -133,20 +133,20 @@ function M.setup()
             end
           elseif action.type == "delete" then
             if action.entry_type == "directory" then
-              projectManager.delete_group(path)
+              projectManager.delete_group(path, config.find_xcodeproj)
             elseif action.entry_type == "file" then
-              projectManager.delete_file(path)
+              projectManager.delete_file(path, config.find_xcodeproj)
             end
           elseif action.type == "move" then
             if action.entry_type == "directory" then
               local destPath = parseUrl(action.dest_url)
               if destPath then
-                projectManager.move_or_rename_group(path, destPath)
+                projectManager.move_or_rename_group(path, destPath, config.find_xcodeproj)
               end
             elseif action.entry_type == "file" then
               local destPath = parseUrl(action.dest_url)
               if destPath then
-                projectManager.move_file(path, destPath)
+                projectManager.move_file(path, destPath, config.find_xcodeproj)
               end
             end
           end

--- a/lua/xcodebuild/integrations/oil-nvim.lua
+++ b/lua/xcodebuild/integrations/oil-nvim.lua
@@ -111,7 +111,8 @@ function M.setup()
               end, {
                 guessTarget = config.guess_target,
                 createGroups = true,
-              }, config.find_xcodeproj)
+                findXcodeproj = config.find_xcodeproj,
+              })
             end)
             coroutine.yield()
           end

--- a/lua/xcodebuild/project/manager.lua
+++ b/lua/xcodebuild/project/manager.lua
@@ -101,7 +101,7 @@ end
 ---In case of error, it sends an error notification and returns an empty table.
 ---@param action string
 ---@param params string[]|nil
----@param search_for_project boolean
+---@param search_for_project boolean|nil
 ---@return string[]
 local function run(action, params, search_for_project)
   local allParams = ""
@@ -525,12 +525,13 @@ end
 
 ---Adds the group to the project.
 ---@param path string
-function M.add_group(path)
+---@param find_xcodeproj boolean
+function M.add_group(path, find_xcodeproj)
   if not helpers.validate_project() or not validate_xcodeproj_tool() then
     return
   end
 
-  run_add_group(path, false)
+  run_add_group(path, find_xcodeproj)
   notifications.send("Group has been added")
 end
 

--- a/lua/xcodebuild/project/manager.lua
+++ b/lua/xcodebuild/project/manager.lua
@@ -70,7 +70,7 @@ local function findXcodeproj_path(path)
   local dir = path
   local cwd = vim.fn.getcwd()
 
-  while dir and dir ~= cwd and dir ~= "/" and dir ~= "" do
+  while dir and dir ~= cwd and dir ~= "/" do
     local xcodeproj = findXcodeproj_file(dir)
     if xcodeproj then
       if xcodeproj == projectConfig.settings.xcodeproj then
@@ -80,10 +80,7 @@ local function findXcodeproj_path(path)
       return xcodeproj
     end
 
-    dir = dir:match("(.*/)[^/]+/?$")
-    if dir and dir:sub(-1) == "/" then
-      dir = dir:sub(1, -2)
-    end
+    dir = vim.fn.fnamemodify(dir, ":h")
   end
 
   return nil

--- a/lua/xcodebuild/project/manager.lua
+++ b/lua/xcodebuild/project/manager.lua
@@ -96,7 +96,7 @@ end
 ---@return boolean # Returns true if an `.xcodeproj` path is found and injected; otherwise, false.
 local function inject_relative_xcodeproj(table, params)
   for _, param in ipairs(params) do
-    if string.find(param, "/") then
+    if vim.startswith(param, "/") then
       local xcodeproj_path = findXcodeproj_path(param)
       if xcodeproj_path then
         table.insert(params, 1, xcodeproj_path)

--- a/lua/xcodebuild/project/manager.lua
+++ b/lua/xcodebuild/project/manager.lua
@@ -315,6 +315,7 @@ end
 ---The group from {filepath} must exist in the project.
 ---@param filepath string
 ---@param targets string[]
+---@param findXcodeproj boolean
 function M.add_file_to_targets(filepath, targets, findXcodeproj)
   if not helpers.validate_project() or not validate_xcodeproj_tool() then
     return
@@ -426,6 +427,7 @@ end
 ---The group from {newFilePath} must exist in the project.
 ---@param oldFilePath string
 ---@param newFilePath string
+---@param findXcodeproj boolean
 function M.move_file(oldFilePath, newFilePath, findXcodeproj)
   if not helpers.validate_project() or not validate_xcodeproj_tool() then
     return

--- a/lua/xcodebuild/project/manager.lua
+++ b/lua/xcodebuild/project/manager.lua
@@ -70,7 +70,7 @@ local function findXcodeproj_path(path)
   local dir = path
   local cwd = vim.fn.getcwd()
 
-  while dir and dir ~= cwd and dir ~= "/" do
+  while dir and dir ~= cwd and dir ~= "/" and dir ~= "" do
     local xcodeproj = findXcodeproj_file(dir)
     if xcodeproj then
       if xcodeproj == projectConfig.settings.xcodeproj then

--- a/lua/xcodebuild/project/manager.lua
+++ b/lua/xcodebuild/project/manager.lua
@@ -70,7 +70,7 @@ local function findXcodeproj_path(path)
   local dir = path
   local cwd = vim.fn.getcwd()
 
-  while dir and dir ~= cwd do
+  while dir and dir ~= cwd and dir ~= "/" do
     local xcodeproj = findXcodeproj_file(dir)
     if xcodeproj then
       if xcodeproj == projectConfig.settings.xcodeproj then


### PR DESCRIPTION
Discussed in detail here
https://github.com/wojciech-kulik/xcodebuild.nvim/discussions/152

@wojciech-kulik one question I had it where to put the option. I put it in each integration separately, but that leaves out commands like "rename current file", which do not use any of the integrations. In this PR those commands just do not use this feature, let me know if I should put this option on a global level rather than per-integration level