### PR TITLE
feat!: removed filetype for logs buffer

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -100,7 +100,7 @@ M.setup({options})                                            *xcodebuild.setup*
         auto_close_on_app_launch = false, -- close logs when app is launched
         auto_close_on_success_build = false, -- close logs when build succeeded (only if auto_open_on_success_build=false)
         auto_focus = true, -- focus logs buffer when opened
-        filetype = "objc", -- file type set for buffer with logs
+        filetype = "", -- file type set for buffer with logs
         open_command = "silent botright 20split {path}", -- command used to open logs panel. You must use {path} variable to load the log file
         logs_formatter = "xcbeautify --disable-colored-output --disable-logging", -- command used to format logs, you can use "" to skip formatting
         only_summary = false, -- if true logs won't be displayed, just xcodebuild.nvim summary

--- a/lua/xcodebuild/core/config.lua
+++ b/lua/xcodebuild/core/config.lua
@@ -36,7 +36,7 @@ local defaults = {
     auto_close_on_app_launch = false, -- close logs when app is launched
     auto_close_on_success_build = false, -- close logs when build succeeded (only if auto_open_on_success_build=false)
     auto_focus = true, -- focus logs buffer when opened
-    filetype = "objc", -- file type set for buffer with logs
+    filetype = "", -- file type set for buffer with logs
     open_command = "silent botright 20split {path}", -- command used to open logs panel. You must use {path} variable to load the log file
     logs_formatter = "xcbeautify --disable-colored-output --disable-logging", -- command used to format logs, you can use "" to skip formatting
     only_summary = false, -- if true logs won't be displayed, just xcodebuild.nvim summary

--- a/lua/xcodebuild/init.lua
+++ b/lua/xcodebuild/init.lua
@@ -116,7 +116,7 @@ end
 ---    auto_close_on_app_launch = false, -- close logs when app is launched
 ---    auto_close_on_success_build = false, -- close logs when build succeeded (only if auto_open_on_success_build=false)
 ---    auto_focus = true, -- focus logs buffer when opened
----    filetype = "objc", -- file type set for buffer with logs
+---    filetype = "", -- file type set for buffer with logs
 ---    open_command = "silent botright 20split {path}", -- command used to open logs panel. You must use {path} variable to load the log file
 ---    logs_formatter = "xcbeautify --disable-colored-output --disable-logging", -- command used to format logs, you can use "" to skip formatting
 ---    only_summary = false, -- if true logs won't be displayed, just xcodebuild.nvim summary


### PR DESCRIPTION
BREAKING CHANGE: previously "objc" filetype was set for logs buffer. However, it significantly affects performance. Therefore, the filetype has been removed, but you can still set it in your config: `logs.filetype = "objc"`