### PR TITLE
chore!: refactored shell commands - improved escaping

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -88,8 +88,8 @@ M.setup({options})                                            *xcodebuild.setup*
       },
       commands = {
         cache_devices = true, -- cache recently loaded devices. Restart Neovim to clean cache.
-        extra_build_args = "-parallelizeTargets", -- extra arguments for `xcodebuild build`
-        extra_test_args = "-parallelizeTargets", -- extra arguments for `xcodebuild test`
+        extra_build_args = { "-parallelizeTargets" }, -- extra arguments for `xcodebuild build`
+        extra_test_args = { "-parallelizeTargets" }, -- extra arguments for `xcodebuild test`
         project_search_max_depth = 3, -- maxdepth of xcodeproj/xcworkspace search while using configuration wizard
         focus_simulator_on_app_launch = true, -- focus simulator window when app is launched
       },
@@ -210,6 +210,7 @@ M.setup({options})                                            *xcodebuild.setup*
 Features                                                   *xcodebuild.features*
 
  - Support for iOS, iPadOS, watchOS, tvOS, visionOS, and macOS.
+ - Support for Swift Packages (building & testing).
  - Project-based configuration.
  - Project Manager to deal with project files without using Xcode.
  - Test Explorer to visually present a tree with all tests and results.
@@ -1086,10 +1087,10 @@ XcodeBuildOptions                      *xcodebuild.core.xcode.XcodeBuildOptions*
     {workingDirectory}  (string|nil)
     {buildForTesting}   (boolean|nil)
     {clean}             (boolean|nil)
-    {projectCommand}    (string|nil)
+    {projectFile}       (string|nil)
     {scheme}            (string)
     {destination}       (string)
-    {extraBuildArgs}    (string|nil)
+    {extraBuildArgs}    (string[])
     {on_stdout}         (function)
     {on_stderr}         (fun(_:any,output:string[],_:any))
     {on_exit}           (fun(_:any,code:number,_:any))
@@ -1100,12 +1101,12 @@ XcodeTestOptions                        *xcodebuild.core.xcode.XcodeTestOptions*
   Fields: ~
     {workingDirectory}  (string|nil)
     {withoutBuilding}   (boolean|nil)
-    {projectCommand}    (string|nil)
+    {projectFile}       (string|nil)
     {scheme}            (string)
     {destination}       (string)
     {testPlan}          (string|nil)
     {testsToRun}        (string[]|nil)
-    {extraTestArgs}     (string|nil)
+    {extraTestArgs}     (string[])
     {on_stdout}         (function)
     {on_stderr}         (fun(_:any,output:string[],_:any))
     {on_exit}           (fun(_:any,code:number,_:any))
@@ -1115,11 +1116,12 @@ XcodeTestOptions                        *xcodebuild.core.xcode.XcodeTestOptions*
 XcodeEnumerateOptions
 
   Fields: ~
-    {projectCommand}  (string)
-    {scheme}          (string)
-    {destination}     (string)
-    {testPlan}        (string)
-    {extraTestArgs}   (string|nil)
+    {workingDirectory}  (string|nil)
+    {projectFile}       (string)
+    {scheme}            (string)
+    {destination}       (string)
+    {testPlan}          (string)
+    {extraTestArgs}     (string[])
 
 
 XcodeBuildSettings                    *xcodebuild.core.xcode.XcodeBuildSettings*
@@ -1164,11 +1166,11 @@ M.get_targets_filemap({derivedDataPath})
 
 
                                         *xcodebuild.core.xcode.get_destinations*
-M.get_destinations({projectCommand}, {scheme}, {workingDirectory}, {callback})
+M.get_destinations({projectFile}, {scheme}, {workingDirectory}, {callback})
   Returns the list of devices which match project requirements.
 
   Parameters: ~
-    {projectCommand}    (string|nil)
+    {projectFile}       (string|nil)
     {scheme}            (string)
     {workingDirectory}  (string|nil)
     {callback}          (fun(destinations:XcodeDevice[]))
@@ -1178,11 +1180,11 @@ M.get_destinations({projectCommand}, {scheme}, {workingDirectory}, {callback})
 
 
                                              *xcodebuild.core.xcode.get_schemes*
-M.get_schemes({projectCommand}, {workingDirectory}, {callback})
+M.get_schemes({projectFile}, {workingDirectory}, {callback})
   Returns the list of schemes for the given project.
 
   Parameters: ~
-    {projectCommand}    (string|nil)
+    {projectFile}       (string|nil)
     {workingDirectory}  (string|nil)
     {callback}          (fun(schemes:string[]))
 
@@ -1218,13 +1220,13 @@ M.get_project_information({xcodeproj}, {workingDirectory}, {callback})
 
 
                                            *xcodebuild.core.xcode.get_testplans*
-M.get_testplans({projectCommand}, {scheme}, {callback})
+M.get_testplans({projectFile}, {scheme}, {callback})
   Returns the list of test plans for the given project.
 
   Parameters: ~
-    {projectCommand}  (string)
-    {scheme}          (string)
-    {callback}        (fun(testPlans:string[]))
+    {projectFile}  (string)
+    {scheme}       (string)
+    {callback}     (fun(testPlans:string[]))
 
   Returns: ~
     (number)   job id
@@ -1241,17 +1243,17 @@ M.build_project({opts})                    *xcodebuild.core.xcode.build_project*
 
 
                                       *xcodebuild.core.xcode.get_build_settings*
-M.get_build_settings({platform}, {projectCommand}, {scheme}, {xcodeprojPath}, {callback})
+M.get_build_settings({platform}, {projectFile}, {scheme}, {xcodeprojPath}, {callback})
   Returns the build settings for the given project.
 
   If one of the settings is not found, it will send an error notification.
 
   Parameters: ~
-    {platform}        (string)
-    {projectCommand}  (string)
-    {scheme}          (string)
-    {xcodeprojPath}   (string)
-    {callback}        (fun(settings:XcodeBuildSettings))
+    {platform}       (string)
+    {projectFile}    (string)
+    {scheme}         (string)
+    {xcodeprojPath}  (string)
+    {callback}       (fun(settings:XcodeBuildSettings))
 
   Returns: ~
     (number|nil)   job id
@@ -1658,7 +1660,6 @@ ProjectSettings
     {os}                (string|nil) OS version (ex. "14.5")
     {platform}          (PlatformId|nil) platform (ex. "iOS")
     {projectFile}       (string|nil) project file path (ex. "path/to/Project.xcodeproj")
-    {projectCommand}    (string|nil) project command (ex. "-project 'path/to/Project.xcodeproj'" or "-workspace 'path/to/Project.xcworkspace'")
     {scheme}            (string|nil) scheme name (ex. "MyApp")
     {destination}       (string|nil) destination (ex. "28B52DAA-BC2F-410B-A5BE-F485A3AFB0BC")
     {bundleId}          (string|nil) bundle identifier (ex. "com.mycompany.myapp")
@@ -3743,12 +3744,12 @@ M.is_enabled()
 
 
                          *xcodebuild.integrations.xcode-build-server.run_config*
-M.run_config({projectCommand}, {scheme})
+M.run_config({projectFile}, {scheme})
   Calls "config" command of xcode-build-server in order to update buildServer.json file.
 
   Parameters: ~
-    {projectCommand}  (string) either "-project 'path/to/project.xcodeproj'" or "-workspace 'path/to/workspace.xcworkspace'"
-    {scheme}          (string)
+    {projectFile}  (string)
+    {scheme}       (string)
 
   Returns: ~
     (number)   job id
@@ -3849,10 +3850,10 @@ M.wrap_command_if_needed({command})
   Wraps the `xcodebuild` command with the workaround script if needed.
 
   Parameters: ~
-    {command}  (string)
+    {command}  (string[])
 
   Returns: ~
-    (string)
+    (string[])
 
 
 ==============================================================================
@@ -4207,10 +4208,18 @@ M.shell({cmd})                                           *xcodebuild.util.shell*
   Runs a shell command and returns the output as a list of strings.
 
   Parameters: ~
-    {cmd}  (string)
+    {cmd}  (string|string[])
 
   Returns: ~
     (string[])
+
+
+M.shellAsync({cmd}, {callback})                     *xcodebuild.util.shellAsync*
+  Runs a shell command and asynchronously.
+
+  Parameters: ~
+    {cmd}       (string|string[])
+    {callback}  (function|nil)
 
 
 M.is_fd_installed()                            *xcodebuild.util.is_fd_installed*
@@ -4226,6 +4235,16 @@ M.merge_array({lhs}, {rhs})                        *xcodebuild.util.merge_array*
   Parameters: ~
     {lhs}  (any[])
     {rhs}  (any[])
+
+  Returns: ~
+    (any[])
+
+
+M.skip_nil({array})                                   *xcodebuild.util.skip_nil*
+  Returns a new array without nil values.
+
+  Parameters: ~
+    {array}  (any[])
 
   Returns: ~
     (any[])

--- a/lua/xcodebuild/code_coverage/coverage.lua
+++ b/lua/xcodebuild/code_coverage/coverage.lua
@@ -126,9 +126,9 @@ function M.export_coverage(xcresultFilepath, callback)
     return
   end
 
-  util.shell("rm -rf '" .. appdata.coverage_report_filepath .. "'")
-
-  xcode.export_code_coverage_report(xcresultFilepath, appdata.coverage_report_filepath, callback_if_set)
+  util.shellAsync({ "rm", "-rf", appdata.coverage_report_filepath }, function()
+    xcode.export_code_coverage_report(xcresultFilepath, appdata.coverage_report_filepath, callback_if_set)
+  end)
 end
 
 ---Toggles the code coverage visibility in all buffers.

--- a/lua/xcodebuild/core/config.lua
+++ b/lua/xcodebuild/core/config.lua
@@ -23,8 +23,8 @@ local defaults = {
   },
   commands = {
     cache_devices = true, -- cache recently loaded devices. Restart Neovim to clean cache.
-    extra_build_args = "-parallelizeTargets", -- extra arguments for `xcodebuild build`
-    extra_test_args = "-parallelizeTargets", -- extra arguments for `xcodebuild test`
+    extra_build_args = { "-parallelizeTargets" }, -- extra arguments for `xcodebuild build`
+    extra_test_args = { "-parallelizeTargets" }, -- extra arguments for `xcodebuild test`
     project_search_max_depth = 4, -- maxdepth of xcodeproj/xcworkspace search while using configuration wizard
     focus_simulator_on_app_launch = true, -- focus simulator window when app is launched
   },

--- a/lua/xcodebuild/docs/features.lua
+++ b/lua/xcodebuild/docs/features.lua
@@ -1,6 +1,7 @@
 ---@mod xcodebuild.features Features
 ---@brief [[
 --- - Support for iOS, iPadOS, watchOS, tvOS, visionOS, and macOS.
+--- - Support for Swift Packages (building & testing).
 --- - Project-based configuration.
 --- - Project Manager to deal with project files without using Xcode.
 --- - Test Explorer to visually present a tree with all tests and results.

--- a/lua/xcodebuild/health.lua
+++ b/lua/xcodebuild/health.lua
@@ -209,7 +209,7 @@ end
 
 local function check_xcodebuild_version()
   local util = require("xcodebuild.util")
-  local response = util.shell("xcodebuild -version 2>/dev/null")
+  local response = util.shell("xcodebuild -version")
   local majorVersion, minorVersion = response[1]:match("Xcode (%d+)%.(%d+)")
 
   if majorVersion then
@@ -231,7 +231,7 @@ end
 
 local function check_ruby_version()
   local util = require("xcodebuild.util")
-  local response = util.shell("ruby --version 2>/dev/null")
+  local response = util.shell("ruby --version")
   local major, minor, patch = response[1]:match("(%d+)%.(%d+)%.(%d+)")
 
   if major and minor then
@@ -279,7 +279,7 @@ end
 
 local function has_sudo_access(path)
   local util = require("xcodebuild.util")
-  local permissions = util.shell("sudo -l 2>/dev/null")
+  local permissions = util.shell("sudo -l")
 
   for _, line in ipairs(permissions) do
     if line:match("NOPASSWD.*" .. path) then
@@ -353,9 +353,22 @@ local function check_plugin_commit()
   local util = require("xcodebuild.util")
   local pathComponents = vim.split(debug.getinfo(1).source:sub(2), "/", { plain = true })
   local pluginDir = table.concat(pathComponents, "/", 1, #pathComponents - 3)
-  local commit = util.shell("git --git-dir '" .. pluginDir .. "/.git' rev-parse --short HEAD 2>/dev/null")[1]
-  local upstreamCommit =
-    util.shell("git --git-dir '" .. pluginDir .. "/.git' rev-parse --short origin/main 2>/dev/null")[1]
+  local commit = util.shell({
+    "git",
+    "--git-dir",
+    pluginDir .. "/.git",
+    "rev-parse",
+    "--short",
+    "HEAD",
+  })[1]
+  local upstreamCommit = util.shell({
+    "git",
+    "--git-dir",
+    pluginDir .. "/.git",
+    "rev-parse",
+    "--short",
+    "origin/main",
+  })[1]
 
   if commit then
     if upstreamCommit and commit ~= upstreamCommit then

--- a/lua/xcodebuild/helpers.lua
+++ b/lua/xcodebuild/helpers.lua
@@ -86,13 +86,27 @@ function M.find_all_swift_files()
 
   local allFiles
   if util.is_fd_installed() then
-    allFiles = util.shell("fd -I '.*\\.swift$' '" .. vim.fn.getcwd() .. "' --type f 2> /dev/null")
+    -- stylua: ignore
+    allFiles = util.shell({
+      "fd",
+      "-I",
+      ".*\\.swift$",
+      vim.fn.getcwd(),
+      "--type", "f",
+    })
   else
-    allFiles = util.shell(
-      "find '"
-        .. vim.fn.getcwd()
-        .. "' -type d -path '*/.*' -prune -o -type f -iname '*.swift' -print 2>/dev/null"
-    )
+    -- stylua: ignore
+    allFiles = util.shell({
+      "find",
+      vim.fn.getcwd(),
+      "-type", "d",
+      "-path", "*/.*",
+      "-prune",
+      "-o",
+      "-type", "f",
+      "-iname", "*.swift",
+      "-print",
+    })
   end
 
   local map = {}

--- a/lua/xcodebuild/init.lua
+++ b/lua/xcodebuild/init.lua
@@ -77,7 +77,15 @@ local function warnAboutOldConfig()
     or config.marks.failure_test_duration_hl
   then
     print("xcodebuild.nvim: Code coverage and marks options related to higlights were changed.")
-    print("xcodebuild.nvim: Please see README.md and update your config.")
+    print("xcodebuild.nvim: Please see `:h xcodebuild.config` and update your config.")
+  end
+
+  if
+    type(config.commands.extra_test_args) == "string"
+    or type(config.commands.extra_build_args) == "string"
+  then
+    print("xcodebuild.nvim: `commands.extra_test_args` and `commands.extra_build_args` should be a table.")
+    print("xcodebuild.nvim: Please see `:h xcodebuild.config` and update your config.")
   end
 end
 
@@ -103,8 +111,8 @@ end
 ---  },
 ---  commands = {
 ---    cache_devices = true, -- cache recently loaded devices. Restart Neovim to clean cache.
----    extra_build_args = "-parallelizeTargets", -- extra arguments for `xcodebuild build`
----    extra_test_args = "-parallelizeTargets", -- extra arguments for `xcodebuild test`
+---    extra_build_args = { "-parallelizeTargets" }, -- extra arguments for `xcodebuild build`
+---    extra_test_args = { "-parallelizeTargets" }, -- extra arguments for `xcodebuild test`
 ---    project_search_max_depth = 3, -- maxdepth of xcodeproj/xcworkspace search while using configuration wizard
 ---    focus_simulator_on_app_launch = true, -- focus simulator window when app is launched
 ---  },

--- a/lua/xcodebuild/integrations/xcode-build-server.lua
+++ b/lua/xcodebuild/integrations/xcode-build-server.lua
@@ -7,6 +7,7 @@
 ---@brief ]]
 
 local config = require("xcodebuild.core.config").options.integrations.xcode_build_server
+local util = require("xcodebuild.util")
 
 local M = {}
 
@@ -23,11 +24,20 @@ function M.is_enabled()
 end
 
 ---Calls "config" command of xcode-build-server in order to update buildServer.json file.
----@param projectCommand string either "-project 'path/to/project.xcodeproj'" or "-workspace 'path/to/workspace.xcworkspace'"
+---@param projectFile string
 ---@param scheme string
 ---@return number # job id
-function M.run_config(projectCommand, scheme)
-  return vim.fn.jobstart("xcode-build-server config " .. projectCommand .. " -scheme '" .. scheme .. "'", {
+function M.run_config(projectFile, scheme)
+  local command = {
+    "xcode-build-server",
+    "config",
+    util.has_suffix(projectFile, "xcodeproj") and "-project" or "-workspace",
+    projectFile,
+    "-scheme",
+    scheme,
+  }
+
+  return vim.fn.jobstart(command, {
     on_exit = function()
       require("xcodebuild.integrations.lsp").restart_sourcekit_lsp()
     end,

--- a/lua/xcodebuild/integrations/xcodebuild-offline.lua
+++ b/lua/xcodebuild/integrations/xcodebuild-offline.lua
@@ -91,7 +91,7 @@ M.scriptPath = vim.fn.expand("~/Library/xcodebuild.nvim/xcodebuild_offline")
 ---Checks whether the `sudo` command has passwordless access to the tool.
 ---@return boolean
 local function check_sudo()
-  local permissions = util.shell("sudo -l 2>/dev/null")
+  local permissions = util.shell("sudo -l")
 
   for _, line in ipairs(permissions) do
     if line:match("NOPASSWD.*" .. M.scriptPath) then
@@ -109,8 +109,8 @@ function M.is_enabled()
 end
 
 ---Wraps the `xcodebuild` command with the workaround script if needed.
----@param command string
----@return string
+---@param command string[]
+---@return string[]
 function M.wrap_command_if_needed(command)
   if not M.is_enabled() then
     return command
@@ -121,7 +121,10 @@ function M.wrap_command_if_needed(command)
     error("xcodebuild.nvim: `xcodebuild_offline` requires passwordless access to the sudo command.")
   end
 
-  return "sudo '" .. M.scriptPath .. "' " .. string.gsub(command, "^xcodebuild ", "", 1)
+  table.insert(command, 1, "sudo")
+  command[2] = M.scriptPath
+
+  return command
 end
 
 return M

--- a/lua/xcodebuild/platform/macos.lua
+++ b/lua/xcodebuild/platform/macos.lua
@@ -14,7 +14,7 @@ local M = {}
 ---@param callback function|nil
 ---@return number # job id
 function M.launch_app(appPath, callback)
-  return vim.fn.jobstart("open '" .. appPath .. "'", {
+  return vim.fn.jobstart({ "open", appPath }, {
     on_exit = function(_, code)
       if code == 0 then
         util.call(callback)

--- a/lua/xcodebuild/project/builder.lua
+++ b/lua/xcodebuild/project/builder.lua
@@ -116,7 +116,7 @@ function M.build_project(opts, callback)
     clean = opts.clean,
     workingDirectory = projectConfig.settings.workingDirectory,
     destination = projectConfig.settings.destination,
-    projectCommand = projectConfig.settings.projectCommand,
+    projectFile = projectConfig.settings.projectFile,
     scheme = projectConfig.settings.scheme,
     extraBuildArgs = config.commands.extra_build_args,
   })
@@ -149,7 +149,7 @@ function M.clean_derived_data()
       notifications.send("Deleting: " .. derivedDataPath .. "...")
 
       -- TODO: should clean targets map?
-      vim.fn.jobstart("rm -rf '" .. derivedDataPath .. "'", {
+      vim.fn.jobstart({ "rm", "-rf", derivedDataPath }, {
         on_exit = function(_, code)
           if code == 0 then
             notifications.send("Deleted: " .. derivedDataPath)

--- a/lua/xcodebuild/project/config.lua
+++ b/lua/xcodebuild/project/config.lua
@@ -13,7 +13,6 @@
 ---@field os string|nil OS version (ex. "14.5")
 ---@field platform PlatformId|nil platform (ex. "iOS")
 ---@field projectFile string|nil project file path (ex. "path/to/Project.xcodeproj")
----@field projectCommand string|nil project command (ex. "-project 'path/to/Project.xcodeproj'" or "-workspace 'path/to/Project.xcworkspace'")
 ---@field scheme string|nil scheme name (ex. "MyApp")
 ---@field destination string|nil destination (ex. "28B52DAA-BC2F-410B-A5BE-F485A3AFB0BC")
 ---@field bundleId string|nil bundle identifier (ex. "com.mycompany.myapp")
@@ -94,7 +93,6 @@ function M.is_project_configured()
   if
     settings.platform
     and settings.projectFile
-    and settings.projectCommand
     and settings.scheme
     and settings.destination
     and settings.bundleId
@@ -132,7 +130,7 @@ function M.update_settings(callback)
   else
     xcode.get_build_settings(
       M.settings.platform,
-      M.settings.projectCommand,
+      M.settings.projectFile,
       M.settings.scheme,
       M.settings.xcodeproj,
       function(buildSettings)

--- a/lua/xcodebuild/project/manager.lua
+++ b/lua/xcodebuild/project/manager.lua
@@ -50,7 +50,15 @@ end
 ---@param dir string # The directory to search in.
 ---@return string|nil # The absolute path to the `.xcodeproj` file, or nil if not found.
 local function findXcodeproj_file(dir)
-  local cmd = "find '" .. dir .. '\' -maxdepth 1 -name "*.xcodeproj" -print -quit 2> /dev/null'
+  -- stylua: ignore
+  local cmd = {
+    "find",
+    dir,
+    "-maxdepth", "1",
+    "-name", "*.xcodeproj",
+    "-print",
+    "-quit",
+  }
   local result = util.shell(cmd)
   if result and #result > 0 and result[1] ~= "" then
     return result[1]
@@ -296,7 +304,7 @@ function M.create_new_file()
   end
 
   local fullPath = path .. "/" .. filename
-  vim.fn.system("touch '" .. fullPath .. "'")
+  vim.fn.system({ "touch", fullPath })
   vim.cmd("e " .. fullPath)
 
   M.add_current_file()
@@ -508,7 +516,7 @@ function M.create_new_group()
   end
 
   local groupPath = path .. "/" .. groupName
-  vim.fn.system("mkdir -p '" .. groupPath .. "'")
+  vim.fn.system({ "mkdir", "-p", groupPath })
 
   run_add_group(groupPath)
   notifications.send("Group has been added")
@@ -613,7 +621,7 @@ function M.delete_current_group()
 
   if input == "y" then
     run_delete_group(groupPath)
-    vim.fn.system("rm -rf '" .. groupPath .. "'")
+    vim.fn.system({ "rm", "-rf", groupPath })
     vim.cmd("bd!")
     notifications.send("Group has been deleted")
   end

--- a/lua/xcodebuild/tests/runner.lua
+++ b/lua/xcodebuild/tests/runner.lua
@@ -59,8 +59,9 @@ function M.reload_tests()
     notifications.send("Loading Tests...")
 
     M.currentJobId = xcode.enumerate_tests({
+      workingDirectory = projectConfig.settings.workingDirectory,
       destination = projectConfig.settings.destination,
-      projectCommand = projectConfig.settings.projectCommand,
+      projectFile = projectConfig.settings.projectFile,
       scheme = projectConfig.settings.scheme,
       testPlan = projectConfig.settings.testPlan,
       extraTestArgs = config.commands.extra_test_args,
@@ -198,7 +199,7 @@ function M.run_tests(testsToRun)
       withoutBuilding = true,
       workingDirectory = projectConfig.settings.workingDirectory,
       destination = projectConfig.settings.destination,
-      projectCommand = projectConfig.settings.projectCommand,
+      projectFile = projectConfig.settings.projectFile,
       scheme = projectConfig.settings.scheme,
       testPlan = projectConfig.settings.testPlan,
       testsToRun = testsToRun,

--- a/lua/xcodebuild/tests/snapshots.lua
+++ b/lua/xcodebuild/tests/snapshots.lua
@@ -26,9 +26,13 @@ function M.save_failing_snapshots(xcresultFilepath, callback)
 
   local savePath = appdata.snapshots_dir
   local getsnapshotPath = appdata.tool_path(appdata.GETSNAPSHOTS_TOOL)
-  local command = getsnapshotPath .. " '" .. xcresultFilepath .. "' '" .. savePath .. "'"
+  local command = {
+    getsnapshotPath,
+    xcresultFilepath,
+    savePath,
+  }
 
-  util.shell("mkdir -p '" .. savePath .. "'")
+  util.shell({ "mkdir", "-p", savePath })
 
   return vim.fn.jobstart(command, {
     on_exit = function(_, code)
@@ -48,7 +52,7 @@ end
 ---@return string[]
 function M.get_failing_snapshots()
   local snapshots = util.filter(
-    util.shell("find '" .. appdata.snapshots_dir .. "' -type f -iname '*.png' 2>/dev/null"),
+    util.shell({ "find", appdata.snapshots_dir, "-type", "f", "-iname", "*.png" }),
     function(item)
       return item ~= ""
     end
@@ -63,7 +67,7 @@ end
 
 ---Deletes the `failing-snapshots` directory.
 function M.delete_snapshots()
-  util.shell("rm -rf '" .. appdata.snapshots_dir .. "'")
+  util.shell({ "rm", "-rf", appdata.snapshots_dir })
 end
 
 return M


### PR DESCRIPTION
BREAKING CHANGES:
- the type of `commands.extra_build_args` and `commands.extra_test_args` options has been changed to `table`
- `projectCommand` from project configuration has been removed
- all functions previously accepting `projectCommand`, now accept `projectFile`