### PR TITLE
fix: zellij + quick look previews (assets and failed snapshot test previews)

### DIFF
--- a/lua/xcodebuild/project/assets.lua
+++ b/lua/xcodebuild/project/assets.lua
@@ -340,8 +340,8 @@ function M.show_asset_picker(reveal)
       })
 
       -- HACK: the preview stays behind the terminal window
-      -- when Neovim is running in tmux.
-      if vim.env.TERM_PROGRAM == "tmux" then
+      -- when Neovim is running in tmux or zellij.
+      if vim.env.TERM_PROGRAM == "tmux" or vim.env.ZELLIJ_PANE_ID then
         vim.defer_fn(function()
           util.shell("open -a qlmanage")
         end, 100)

--- a/lua/xcodebuild/ui/pickers.lua
+++ b/lua/xcodebuild/ui/pickers.lua
@@ -733,8 +733,8 @@ function M.select_failing_snapshot_test()
     })
 
     -- HACK: the preview stays behind the terminal window
-    -- when Neovim is running in tmux.
-    if vim.env.TERM_PROGRAM == "tmux" then
+    -- when Neovim is running in tmux or zellij.
+    if vim.env.TERM_PROGRAM == "tmux" or vim.env.ZELLIJ_PANE_ID then
       vim.defer_fn(function()
         util.shell("open -a qlmanage")
       end, 100)


### PR DESCRIPTION
Fix issue where Quick Look previews appear behind the terminal window when running Neovim inside of a zellij session:
- Added a check for a non-null zellij pane id (either an integer or nil) to the tmux hack in asset manager and snapshot test picker.
https://github.com/wojciech-kulik/xcodebuild.nvim/issues/271