### PR TITLE
feat(previews): integration with hot reload (via Inject) to make previews faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ support and [xcodebuild-nvim-preview] package to add previews to your project.
 See [Wiki](https://github.com/wojciech-kulik/xcodebuild.nvim/wiki/Integrations#-previews)
 for more details.
 
-https://github.com/user-attachments/assets/5f9c9276-e477-4c56-b599-2ef7cb262961
+https://github.com/user-attachments/assets/ec6c6e96-667a-40a3-a9d3-a75c9c9cf272
 
 &nbsp;
 

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -182,7 +182,7 @@ M.setup({options})                                            *xcodebuild.setup*
         end,
       },
       previews = {
-        open_command = "vertical botright split +vertical\\ resize\\ 50 %s | wincmd p", -- command used to open preview window
+        open_command = "vertical botright split +vertical\\ resize\\ 42 %s | wincmd p", -- command used to open preview window
         show_notifications = true, -- show preview-related notifications
       },
       device_picker = {
@@ -479,13 +479,13 @@ Project Manager
 
 Previews
 
- | Command                            | Description                                                |
- | ---------------------------------- | ---------------------------------------------------------- |
- | `XcodebuildPreviewGenerate`           | Generate preview                                        |
- | `XcodebuildPreviewGenerateAndShow`    | Generate and show preview                               |
- | `XcodebuildPreviewShow`               | Show preview                                            |
- | `XcodebuildPreviewHide`               | Hide preview                                            |
- | `XcodebuildPreviewToggle`             | Toggle preview                                          |
+ | Command                            | Description                                                   |
+ | ---------------------------------- | ------------------------------------------------------------- |
+ | `XcodebuildPreviewGenerate`           | Generate preview (optional parameter: `hotReload`)         |
+ | `XcodebuildPreviewGenerateAndShow`    | Generate and show preview (optional parameter `hotReload`) |
+ | `XcodebuildPreviewShow`               | Show preview                                               |
+ | `XcodebuildPreviewHide`               | Hide preview                                               |
+ | `XcodebuildPreviewToggle`             | Toggle preview                                             |
 
 Testing
 
@@ -871,19 +871,24 @@ M.jump_to_previous_coverage()
   Jumps to the previous coverage marker.
 
 
-M.previews_generate({callback})           *xcodebuild.actions.previews_generate*
+                                          *xcodebuild.actions.previews_generate*
+M.previews_generate({hotReload}, {callback})
   Generates the preview.
+  If {hotReload} is true, the app will be kept running.
 
   Parameters: ~
-    {callback}  (function|nil)
+    {hotReload}  (boolean|nil)
+    {callback}   (function|nil)
 
 
                                  *xcodebuild.actions.previews_generate_and_show*
-M.previews_generate_and_show({callback})
+M.previews_generate_and_show({hotReload}, {callback})
   Generates and shows the preview.
+  If {hotReload} is true, the app will be kept running.
 
   Parameters: ~
-    {callback}  (function|nil)
+    {hotReload}  (boolean|nil)
+    {callback}   (function|nil)
 
 
 M.previews_show()                             *xcodebuild.actions.previews_show*
@@ -1588,10 +1593,27 @@ Installation:
  - Install the `snacks.nvim` plugin to enable image support.
  - Make sure that `image` snack is enabled.
  - Install Swift Package `wojciech-kulik/xcodebuild-nvim-preview` in your project.
- - Configure the preview in `application(_:didFinishLaunchingWithOptions:)` function.
-   You can also try putting it somewhere else, but it must be triggered automatically
-   after the app launch without user interaction.
+ - Configure the preview in a place that gets automatically called when the app starts.
 
+Examples:
+
+SwiftUI (supports hot reload):
+>swift
+    import SwiftUI
+    import XcodebuildNvimPreview
+
+    @main
+    struct MyApp: App {
+        var body: some Scene {
+            WindowGroup {
+                MainView()
+                  .setupNvimPreview { HomeView() }
+            }
+        }
+    }
+<
+
+UIKit (similar for AppKit):
 >swift
     import XcodebuildNvimPreview
 
@@ -1600,16 +1622,29 @@ Installation:
 
         XcodebuildNvimPreview.setup(view: MainView())
 
+        // (optional) enable hot reload for preview (requires integration with `Inject`)
+        observeHotReload()
+            .sink { XcodebuildNvimPreview.setup(view: HomeView()) }
+            .store(in: &cancellables)
+
         return true
     }
 <
 
  - Run `:XcodebuildPreviewGenerateAndShow` to generate and show the preview.
+   Alternatively, run `:XcodebuildPreviewGenerateAndShow hotReload` to keep
+   the app running for hot reloading.
 
 WARNING: snacks.nvim doesn't support clearing the in-memory cache right now, which makes it
 impossible to refresh previews without restarting Neovim. If you want to use this feature,
 you either need to wait until it is added (github.com/folke/snacks.nvim/issues/1394) or
 you can use my fork where I removed the cache: wojciech-kulik/snacks.nvim.
+
+If you want to use the hot reload feature, you need to integrate your app with `Inject`,
+read more about it here: https://github.com/wojciech-kulik/xcodebuild.nvim/wiki/Tips-&-Tricks#hot-reload
+
+M.cancel()                                     *xcodebuild.core.previews.cancel*
+  Cancels awaiting preview generation.
 
 
 M.show_preview()                         *xcodebuild.core.previews.show_preview*
@@ -1625,13 +1660,15 @@ M.toggle_preview()                     *xcodebuild.core.previews.toggle_preview*
 
 
                                      *xcodebuild.core.previews.generate_preview*
-M.generate_preview({callback})
+M.generate_preview({hotReload}, {callback})
   Builds & runs the project to generate a preview.
   If successful, the preview will be saved in `/tmp/xcodebuild.nvim/<product-name>.png`.
+  If {hotReload} is true, the app will be kept running to allow hot reloading using `Inject`.
   The {callback} function is called after the preview is generated.
 
   Parameters: ~
-    {callback}  (function|nil)
+    {hotReload}  (boolean|nil)
+    {callback}   (function|nil)
 
 
 M.get_actions()                           *xcodebuild.core.previews.get_actions*

--- a/lua/xcodebuild/actions.lua
+++ b/lua/xcodebuild/actions.lua
@@ -282,15 +282,21 @@ end
 -- Previews
 
 ---Generates the preview.
+---If {hotReload} is true, the app will be kept running.
+---@param hotReload boolean|nil
 ---@param callback function|nil
-function M.previews_generate(callback)
-  previews.generate_preview(callback)
+function M.previews_generate(hotReload, callback)
+  helpers.cancel_actions()
+  previews.generate_preview(hotReload, callback)
 end
 
 ---Generates and shows the preview.
+---If {hotReload} is true, the app will be kept running.
+---@param hotReload boolean|nil
 ---@param callback function|nil
-function M.previews_generate_and_show(callback)
-  previews.generate_preview(function()
+function M.previews_generate_and_show(hotReload, callback)
+  helpers.cancel_actions()
+  previews.generate_preview(hotReload, function()
     M.previews_show()
     util.call(callback)
   end)

--- a/lua/xcodebuild/core/config.lua
+++ b/lua/xcodebuild/core/config.lua
@@ -117,7 +117,7 @@ local defaults = {
     end,
   },
   previews = {
-    open_command = "vertical botright split +vertical\\ resize\\ 50 %s | wincmd p", -- command used to open preview window
+    open_command = "vertical botright split +vertical\\ resize\\ 42 %s | wincmd p", -- command used to open preview window
     show_notifications = true, -- show preview-related notifications
   },
   device_picker = {

--- a/lua/xcodebuild/docs/commands.lua
+++ b/lua/xcodebuild/docs/commands.lua
@@ -42,13 +42,13 @@
 ---
 ---Previews
 ---
---- | Command                            | Description                                                |
---- | ---------------------------------- | ---------------------------------------------------------- |
---- | `XcodebuildPreviewGenerate`           | Generate preview                                        |
---- | `XcodebuildPreviewGenerateAndShow`    | Generate and show preview                               |
---- | `XcodebuildPreviewShow`               | Show preview                                            |
---- | `XcodebuildPreviewHide`               | Hide preview                                            |
---- | `XcodebuildPreviewToggle`             | Toggle preview                                          |
+--- | Command                            | Description                                                   |
+--- | ---------------------------------- | ------------------------------------------------------------- |
+--- | `XcodebuildPreviewGenerate`           | Generate preview (optional parameter: `hotReload`)         |
+--- | `XcodebuildPreviewGenerateAndShow`    | Generate and show preview (optional parameter `hotReload`) |
+--- | `XcodebuildPreviewShow`               | Show preview                                               |
+--- | `XcodebuildPreviewHide`               | Hide preview                                               |
+--- | `XcodebuildPreviewToggle`             | Toggle preview                                             |
 ---
 ---Testing
 ---

--- a/lua/xcodebuild/helpers.lua
+++ b/lua/xcodebuild/helpers.lua
@@ -42,6 +42,8 @@ function M.cancel_actions()
   cancel(require("xcodebuild.platform.device"))
   cancel(require("xcodebuild.project.builder"))
   cancel(require("xcodebuild.tests.runner"))
+  require("xcodebuild.core.previews").cancel()
+  require("xcodebuild.platform.device").kill_app()
 end
 
 ---Validates if the project is configured.

--- a/lua/xcodebuild/init.lua
+++ b/lua/xcodebuild/init.lua
@@ -201,7 +201,7 @@ end
 ---    end,
 ---  },
 ---  previews = {
----    open_command = "vertical botright split +vertical\\ resize\\ 50 %s | wincmd p", -- command used to open preview window
+---    open_command = "vertical botright split +vertical\\ resize\\ 42 %s | wincmd p", -- command used to open preview window
 ---    show_notifications = true, -- show preview-related notifications
 ---  },
 ---  device_picker = {
@@ -286,8 +286,20 @@ function M.setup(options)
   vim.api.nvim_create_user_command("XcodebuildCancel", call(actions.cancel), { nargs = 0 })
 
   -- Previews
-  vim.api.nvim_create_user_command("XcodebuildPreviewGenerate", call(actions.previews_generate), { nargs = 0 })
-  vim.api.nvim_create_user_command("XcodebuildPreviewGenerateAndShow", call(actions.previews_generate_and_show), { nargs = 0 })
+  vim.api.nvim_create_user_command("XcodebuildPreviewGenerate",
+    function(opts)
+        ---@diagnostic disable-next-line: undefined-field
+        actions.previews_generate(opts.fargs[1] == "hotReload")
+    end,
+    { nargs = "?", complete = function() return { "hotReload" } end }
+  )
+  vim.api.nvim_create_user_command("XcodebuildPreviewGenerateAndShow",
+    function(opts)
+        ---@diagnostic disable-next-line: undefined-field
+        actions.previews_generate_and_show(opts.fargs[1] == "hotReload")
+    end,
+    { nargs = "?", complete = function() return { "hotReload" } end }
+  )
   vim.api.nvim_create_user_command("XcodebuildPreviewShow", call(actions.previews_show), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildPreviewHide", call(actions.previews_hide), { nargs = 0 })
   vim.api.nvim_create_user_command("XcodebuildPreviewToggle", call(actions.previews_toggle), { nargs = 0 })


### PR DESCRIPTION
See: `:h xcodebuild.previews`

Make sure to update Swift Package `xcodebuild-nvim-preview`, minimum version: `1.0.9`

Hot reload integration: https://github.com/wojciech-kulik/xcodebuild.nvim/wiki/Tips-&-Tricks#hot-reload
Updated instruction: https://github.com/wojciech-kulik/xcodebuild.nvim/wiki/Integrations#-previews

Now commands accept the optional `hotReload` parameter:
- `XcodebuildPreviewGenerateAndShow hotReload`
- `XcodebuildPreviewGenerate hotReload`

https://github.com/user-attachments/assets/ec6c6e96-667a-40a3-a9d3-a75c9c9cf272

