### PR TITLE
Route output of macOS apps to 'app_logs.log' and DAP console

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -2754,12 +2754,14 @@ macOS Platform Integration                           *xcodebuild.platform.macos*
 
 This module is responsible for the integration of macOS platform with `nvim-dap`.
 
-M.launch_app({appPath}, {callback})       *xcodebuild.platform.macos.launch_app*
+                                          *xcodebuild.platform.macos.launch_app*
+M.launch_app({appPath}, {productName}, {callback})
   Simply starts the application on macOS.
 
   Parameters: ~
-    {appPath}   (string)
-    {callback}  (function|nil)
+    {appPath}      (string)
+    {productName}  (string)
+    {callback}     (function|nil)
 
   Returns: ~
     (number)   job id

--- a/lua/xcodebuild/platform/device.lua
+++ b/lua/xcodebuild/platform/device.lua
@@ -41,7 +41,7 @@ local function launch_app(waitForDebugger, callback)
       return macos.launch_and_debug(settings.appPath, finished)
     else
       vim.defer_fn(function()
-        macos.launch_app(settings.appPath, finished)
+        macos.launch_app(settings.appPath, settings.productName, finished)
       end, 300)
       return nil
     end

--- a/lua/xcodebuild/platform/macos.lua
+++ b/lua/xcodebuild/platform/macos.lua
@@ -16,8 +16,14 @@ local M = {}
 ---@return number # job id
 function M.launch_app(appPath, productName, callback)
   local executablePath = appPath .. "/Contents/MacOS/" .. productName
-  local args = table.concat(appdata.read_run_args() or {}, " ")
-  local command = executablePath .. " " .. args
+  local command = { executablePath }
+
+  local runArgs = appdata.read_run_args()
+  if runArgs then
+    for _, value in ipairs(runArgs) do
+      table.insert(command, value)
+    end
+  end
 
   local function write_logs(_, output)
     if output[#output] == "" then

--- a/lua/xcodebuild/platform/macos.lua
+++ b/lua/xcodebuild/platform/macos.lua
@@ -16,15 +16,8 @@ local M = {}
 ---@return number # job id
 function M.launch_app(appPath, productName, callback)
   local executablePath = appPath .. "/Contents/MacOS/" .. productName
-  local command = { executablePath }
-
-  local runArgs = appdata.read_run_args()
-  if runArgs then
-    table.insert(command, "--args")
-    for _, value in ipairs(runArgs) do
-      table.insert(command, value)
-    end
-  end
+  local args = table.concat(appdata.read_run_args() or {}, " ")
+  local command = executablePath .. " " .. args
 
   local function write_logs(_, output)
     if output[#output] == "" then

--- a/lua/xcodebuild/platform/macos.lua
+++ b/lua/xcodebuild/platform/macos.lua
@@ -11,11 +11,11 @@ local M = {}
 
 ---Simply starts the application on macOS.
 ---@param appPath string
+---@param productName string
 ---@param callback function|nil
 ---@return number # job id
-function M.launch_app(appPath, callback)
-  local appName = util.get_filename(appPath)
-  local executablePath = appPath .. "/Contents/MacOS/" .. appName
+function M.launch_app(appPath, productName, callback)
+  local executablePath = appPath .. "/Contents/MacOS/" .. productName
   local command = { executablePath }
 
   local runArgs = appdata.read_run_args()


### PR DESCRIPTION
I've noticed that log messages of macOS apps don't appear in the DAP console unless the debugger is attached. To fix this, I modified the launch process to run the app's binary directly from the bundle and attach a pseudo terminal session. Based on my tests, both steps are required to capture log messages while the app is still running.  

This is my first PR to this project—feel free to suggest any changes! 👍