### PR TITLE
fix(tests): regex for detecting test class name

### DIFF
--- a/lua/xcodebuild/tests/provider.lua
+++ b/lua/xcodebuild/tests/provider.lua
@@ -36,7 +36,7 @@ function M.find_tests(opts)
   local selectedTests = {}
 
   for _, line in ipairs(lines) do
-    selectedClass = string.match(line, "^%s*class ([^:%s]+)%s*:?")
+    selectedClass = string.match(line, "^[^\\/]*class ([^:%s]+)%s*:?")
     if selectedClass then
       break
     end

--- a/lua/xcodebuild/tests/provider.lua
+++ b/lua/xcodebuild/tests/provider.lua
@@ -36,7 +36,7 @@ function M.find_tests(opts)
   local selectedTests = {}
 
   for _, line in ipairs(lines) do
-    selectedClass = string.match(line, "^[^\\/]*class ([^:%s]+)%s*:?")
+    selectedClass = string.match(line, "^[^/]*class ([^:%s]+)%s*:?")
     if selectedClass then
       break
     end

--- a/lua/xcodebuild/tests/provider.lua
+++ b/lua/xcodebuild/tests/provider.lua
@@ -36,7 +36,7 @@ function M.find_tests(opts)
   local selectedTests = {}
 
   for _, line in ipairs(lines) do
-    selectedClass = string.match(line, "class ([^:%s]+)%s*:?")
+    selectedClass = string.match(line, "^%s*class ([^:%s]+)%s*:?")
     if selectedClass then
       break
     end


### PR DESCRIPTION
I've noticed that some of my test classes wouldn't run because I had comments above the class definition.  

For example:  

```swift
/// This class contains tests for ...
class MyTests { ... }
```  

In this case, the plugin mistakenly detects `contains` as the class name, preventing the tests from running.  

I've updated the regex to match only `class` keywords that appear at the beginning of a line.