### PR TITLE
fix(macos)!: invalid app permissions when running app without debugger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test:
 # Installs dependencies for plugin usage
 install:
 	brew update --quiet
-	brew install --quiet xcode-build-server xcbeautify ruby pipx rg jq
+	brew install --quiet xcode-build-server xcbeautify ruby pipx rg jq coreutils
 	pipx install pymobiledevice3 --quiet
 	gem install --quiet xcodeproj
 

--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -309,7 +309,7 @@ External tools
 
 Installation
 >bash
-  brew install xcode-build-server xcbeautify ruby pipx rg jq
+  brew install xcode-build-server xcbeautify ruby pipx rg jq coreutils
   gem install xcodeproj
   pipx install pymobiledevice3
 <
@@ -758,16 +758,6 @@ M.edit_run_args()                             *xcodebuild.actions.edit_run_args*
 
 M.run({callback})                                       *xcodebuild.actions.run*
   Launches the app.
-
-  Parameters: ~
-    {callback}  (function|nil)
-
-
-                                     *xcodebuild.actions.run_macos_app_detached*
-M.run_macos_app_detached({callback})
-  Launches macOS app detached.
-  For macOS apps the process is by default attached to Neovim,
-  which allows to print logs to DAP console.
 
   Parameters: ~
     {callback}  (function|nil)
@@ -2503,13 +2493,11 @@ M.kill_app({callback})                     *xcodebuild.platform.device.kill_app*
     {callback}  (function|nil)
 
 
-                                            *xcodebuild.platform.device.run_app*
-M.run_app({waitForDebugger}, {detached}, {callback})
+M.run_app({waitForDebugger}, {callback})    *xcodebuild.platform.device.run_app*
   Runs the application on device, simulator, or macOS.
 
   Parameters: ~
     {waitForDebugger}  (boolean)
-    {detached}         (boolean|nil) # affects only macOS platform
     {callback}         (function|nil)
 
 
@@ -2766,15 +2754,12 @@ macOS Platform Integration                           *xcodebuild.platform.macos*
 
 This module is responsible for the integration of macOS platform with `nvim-dap`.
 
-                                          *xcodebuild.platform.macos.launch_app*
-M.launch_app({appPath}, {productName}, {detached}, {callback})
+M.launch_app({appPath}, {callback})       *xcodebuild.platform.macos.launch_app*
   Simply starts the application on macOS.
 
   Parameters: ~
-    {appPath}      (string)
-    {productName}  (string)
-    {detached}     (boolean|nil)
-    {callback}     (function|nil)
+    {appPath}   (string)
+    {callback}  (function|nil)
 
   Returns: ~
     (number)   job id

--- a/lua/xcodebuild/actions.lua
+++ b/lua/xcodebuild/actions.lua
@@ -130,16 +130,7 @@ end
 ---@param callback function|nil
 function M.run(callback)
   helpers.cancel_actions()
-  device.run_app(false, nil, callback)
-end
-
----Launches macOS app detached.
----For macOS apps the process is by default attached to Neovim,
----which allows to print logs to DAP console.
----@param callback function|nil
-function M.run_macos_app_detached(callback)
-  helpers.cancel_actions()
-  device.run_app(false, true, callback)
+  device.run_app(false, callback)
 end
 
 ---Starts tests.

--- a/lua/xcodebuild/docs/requirements.lua
+++ b/lua/xcodebuild/docs/requirements.lua
@@ -24,7 +24,7 @@
 ---
 ---Installation
 --->bash
----  brew install xcode-build-server xcbeautify ruby pipx rg jq
+---  brew install xcode-build-server xcbeautify ruby pipx rg jq coreutils
 ---  gem install xcodeproj
 ---  pipx install pymobiledevice3
 ---<

--- a/lua/xcodebuild/health.lua
+++ b/lua/xcodebuild/health.lua
@@ -35,6 +35,11 @@ local optional_dependencies = {
     url = "https://github.com/sharkdp/fd",
     message = "Improves performance when searching for files. Required for Assets Manager.",
   },
+  {
+    binary = "stdbuf",
+    url = "https://formulae.brew.sh/formula/coreutils#default",
+    message = "Allows to see macOS app logs without launching debugger.",
+  },
 }
 
 local required_dependencies = {

--- a/lua/xcodebuild/integrations/dap.lua
+++ b/lua/xcodebuild/integrations/dap.lua
@@ -201,7 +201,7 @@ function M.build_and_debug(callback)
       if isSimulator then
         start_dap()
       end
-      device.run_app(true, nil, callback)
+      device.run_app(true, callback)
     end
   end)
 end
@@ -229,7 +229,7 @@ function M.debug_without_build(callback)
     if isSimulator then
       start_dap()
     end
-    device.run_app(true, nil, callback)
+    device.run_app(true, callback)
   end
 end
 

--- a/lua/xcodebuild/platform/device.lua
+++ b/lua/xcodebuild/platform/device.lua
@@ -22,10 +22,9 @@ local M = {
 
 ---Launches the application on device, simulator, or macOS.
 ---@param waitForDebugger boolean
----@param detached boolean|nil # affects only macOS platform
 ---@param callback function|nil
 ---@return number|nil # job id
-local function launch_app(waitForDebugger, detached, callback)
+local function launch_app(waitForDebugger, callback)
   local settings = projectConfig.settings
   local function finished()
     notifications.send("Application has been launched")
@@ -42,7 +41,7 @@ local function launch_app(waitForDebugger, detached, callback)
       return macos.launch_and_debug(settings.appPath, finished)
     else
       vim.defer_fn(function()
-        macos.launch_app(settings.appPath, settings.productName, detached, finished)
+        macos.launch_app(settings.appPath, finished)
       end, 300)
       return nil
     end
@@ -83,9 +82,8 @@ end
 
 ---Runs the application on device, simulator, or macOS.
 ---@param waitForDebugger boolean
----@param detached boolean|nil # affects only macOS platform
 ---@param callback function|nil
-function M.run_app(waitForDebugger, detached, callback)
+function M.run_app(waitForDebugger, callback)
   if not helpers.validate_project({ requiresApp = true }) then
     return
   end
@@ -98,10 +96,10 @@ function M.run_app(waitForDebugger, detached, callback)
   end
 
   if projectConfig.settings.platform == constants.Platform.MACOS then
-    M.currentJobId = launch_app(waitForDebugger, detached, callback)
+    M.currentJobId = launch_app(waitForDebugger, callback)
   else
     M.currentJobId = M.install_app(function()
-      M.currentJobId = launch_app(waitForDebugger, nil, callback)
+      M.currentJobId = launch_app(waitForDebugger, callback)
     end)
   end
 end

--- a/lua/xcodebuild/project/builder.lua
+++ b/lua/xcodebuild/project/builder.lua
@@ -36,7 +36,7 @@ function M.build_and_run_app(waitForDebugger, callback)
     end
 
     local device = require("xcodebuild.platform.device")
-    device.run_app(waitForDebugger, nil, callback)
+    device.run_app(waitForDebugger, callback)
   end)
 end
 

--- a/lua/xcodebuild/ui/picker_actions.lua
+++ b/lua/xcodebuild/ui/picker_actions.lua
@@ -56,20 +56,6 @@ local function add_test_actions(actionsNames, actionsPointers)
   end
 end
 
-local function add_macos_actions(actionsNames, actionsPointers)
-  local actions = require("xcodebuild.actions")
-  local macOS = require("xcodebuild.core.constants").Platform.MACOS
-  local runIndex = util.indexOf(actionsNames, "Cancel Running Action")
-  if not runIndex then
-    return
-  end
-
-  if require("xcodebuild.project.config").settings.platform == macOS then
-    table.insert(actionsNames, runIndex, "Run Without Building (Detached)")
-    table.insert(actionsPointers, runIndex, actions.run_macos_app_detached)
-  end
-end
-
 ---Adds DAP actions to the list of actions.
 ---@param actionsNames string[]
 ---@param actionsPointers function[]
@@ -349,7 +335,6 @@ function M.show_xcode_project_actions()
     actions.open_in_xcode,
   }
 
-  add_macos_actions(actionsNames, actionsPointers)
   add_test_actions(actionsNames, actionsPointers)
   add_dap_actions(actionsNames, actionsPointers)
   add_previews_actions(actionsNames, actionsPointers)


### PR DESCRIPTION
Resolves #316

To see macOS app logs without debugger, install coreutils: `brew install coreutils`.

Now, macOS app always starts detached from Neovim's process.