### PR TITLE
fix(schemes): not showing schemes when using xcworkspace with multiple projects

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -1320,12 +1320,12 @@ M.find_schemes({xcodeprojPath}, {workingDirectory}, {callback})
 
 
                                  *xcodebuild.core.xcode.get_project_information*
-M.get_project_information({xcodeproj}, {workingDirectory}, {callback})
+M.get_project_information({projectFile}, {workingDirectory}, {callback})
   Returns the list of project information including schemes, configs, and
-  targets for the given {xcodeproj}.
+  targets for the given {projectFile}.
 
   Parameters: ~
-    {xcodeproj}         (string|nil)
+    {projectFile}       (string|nil)
     {workingDirectory}  (string|nil)
     {callback}          (fun(settings:XcodeProjectInfo))
 

--- a/lua/xcodebuild/core/xcode.lua
+++ b/lua/xcodebuild/core/xcode.lua
@@ -362,19 +362,19 @@ function M.find_schemes(xcodeprojPath, workingDirectory, callback)
 end
 
 ---Returns the list of project information including schemes, configs, and
----targets for the given {xcodeproj}.
----@param xcodeproj string|nil
+---targets for the given {projectFile}.
+---@param projectFile string|nil
 ---@param workingDirectory string|nil
 ---@param callback fun(settings: XcodeProjectInfo)
 ---@return number # job id
-function M.get_project_information(xcodeproj, workingDirectory, callback)
+function M.get_project_information(projectFile, workingDirectory, callback)
   local command = { "xcodebuild", "-list" }
 
-  if xcodeproj then
+  if projectFile then
     command = {
       "xcodebuild",
-      "-project",
-      xcodeproj,
+      get_project_param(projectFile),
+      projectFile,
       "-list",
     }
   end


### PR DESCRIPTION
Added "[Reload Schemes]" option to fetch all schemes using xcodebuild command.

Resolves #330