### PR TITLE
fix(dap)!: debbuging on real iOS 18.2+ device

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -671,6 +671,15 @@ Please also note that remote debugger config options have been moved to:
 `integrations.pymobiledevice`.
 
 
+                                             *xcodebuild.remote-debugger-update*
+To update the `remote_debugger` script, you can run:
+
+>bash
+ DEST="$HOME/Library/xcodebuild.nvim" && \
+    SOURCE="$HOME/.local/share/nvim/lazy/xcodebuild.nvim/tools/remote_debugger" && \
+    sudo install -m 755 -o root "$SOURCE" "$DEST"
+<
+
 ==============================================================================
 Health Check                                                 *xcodebuild.health*
 
@@ -2540,7 +2549,7 @@ For other devices, the |xcodebuild.core.xcode| module is used.
 
 The tool can be installed by:
 >bash
-    python3 -m pip install -U pymobiledevice
+    pipx install pymobiledevice3
 <
 
 See:
@@ -2719,7 +2728,7 @@ M.start_server({destination}, {port}, {callback})
 
 
                          *xcodebuild.platform.device_proxy.create_secure_tunnel*
-M.create_secure_tunnel({destination}, {callback})
+M.create_secure_tunnel({destination}, {service}, {callback})
   Creates a secure tunnel with the device.
   It is used on devices with iOS 17 and above.
 
@@ -2736,6 +2745,7 @@ M.create_secure_tunnel({destination}, {callback})
 
   Parameters: ~
     {destination}  (string) # device id
+    {service}      (string) # lockdown (17.4+) or remote
     {callback}     (fun(rsd:string)|nil)
 
   Returns: ~
@@ -3970,6 +3980,23 @@ M.mode
     (RemoteDebuggerMode)
 
 
+                       *xcodebuild.integrations.remote_debugger.secured_service*
+M.secured_service
+
+  Type: ~
+    (string)  # lockdown or remote
+
+
+                   *xcodebuild.integrations.remote_debugger.set_secured_service*
+M.set_secured_service({service})
+  Sets the service for secured mode.
+  iOS 18.2 requires `lockdown` instead of `remote`.
+  `lockdown` can be used starting from iOS 17.4.
+
+  Parameters: ~
+    {service}  (string)
+
+
                               *xcodebuild.integrations.remote_debugger.set_mode*
 M.set_mode({mode})
   Sets the mode of the remote debugger.
@@ -4562,6 +4589,14 @@ M.find_all_swift_files()               *xcodebuild.helpers.find_all_swift_files*
 
 M.get_major_os_version()               *xcodebuild.helpers.get_major_os_version*
   Returns the major version of the OS (ex. 17 for 17.1.1).
+  It uses the device from the project configuration.
+
+  Returns: ~
+    (number|nil)
+
+
+M.get_minor_os_version()               *xcodebuild.helpers.get_minor_os_version*
+  Returns the minor version of the OS (ex. 1 for 17.1.2).
   It uses the device from the project configuration.
 
   Returns: ~

--- a/lua/xcodebuild/docs/ios17.lua
+++ b/lua/xcodebuild/docs/ios17.lua
@@ -72,6 +72,17 @@
 ---`integrations.pymobiledevice`.
 ---
 ---@brief ]]
+---
+---@tag xcodebuild.remote-debugger-update
+---@brief [[
+---To update the `remote_debugger` script, you can run:
+---
+--->bash
+--- DEST="$HOME/Library/xcodebuild.nvim" && \
+---    SOURCE="$HOME/.local/share/nvim/lazy/xcodebuild.nvim/tools/remote_debugger" && \
+---    sudo install -m 755 -o root "$SOURCE" "$DEST"
+---<
+---@brief ]]
 
 local M = {}
 return M

--- a/lua/xcodebuild/helpers.lua
+++ b/lua/xcodebuild/helpers.lua
@@ -163,6 +163,14 @@ function M.get_major_os_version()
   return settings.os and tonumber(vim.split(settings.os, ".", { plain = true })[1]) or nil
 end
 
+---Returns the minor version of the OS (ex. 1 for 17.1.2).
+---It uses the device from the project configuration.
+---@return number|nil
+function M.get_minor_os_version()
+  local settings = require("xcodebuild.project.config").settings
+  return settings.os and tonumber(vim.split(settings.os, ".", { plain = true })[2]) or nil
+end
+
 ---Wraps any nvim_buf_set_option() call to ensure forward compatibility.
 ---The function is required because nvim_buf_set_option() was deprecated in nvim-0.10.
 ---@param bufnr number

--- a/lua/xcodebuild/integrations/dap.lua
+++ b/lua/xcodebuild/integrations/dap.lua
@@ -58,12 +58,32 @@ local M = {}
 
 ---Sets the remote debugger mode based on the OS version.
 local function set_remote_debugger_mode()
+  local isWatchOS = projectConfig.settings.platform == constants.Platform.WATCHOS_DEVICE
+  local isVisionOS = projectConfig.settings.platform == constants.Platform.VISIONOS_DEVICE
+
+  if isWatchOS or isVisionOS then
+    remoteDebugger.set_mode(remoteDebugger.SECURED_MODE)
+    remoteDebugger.set_secured_service("lockdown")
+    return
+  end
+
+  -- iOS / iPadOS / tvOS
+
   local majorVersion = helpers.get_major_os_version()
+  local minorVersion = helpers.get_minor_os_version()
 
   if majorVersion and majorVersion < 17 then
     remoteDebugger.set_mode(remoteDebugger.LEGACY_MODE)
   else
     remoteDebugger.set_mode(remoteDebugger.SECURED_MODE)
+    majorVersion = majorVersion or 0
+    minorVersion = minorVersion or 0
+
+    if (majorVersion == 17 and minorVersion >= 4) or (majorVersion > 17) then
+      remoteDebugger.set_secured_service("lockdown")
+    else
+      remoteDebugger.set_secured_service("remote")
+    end
   end
 end
 

--- a/tools/remote_debugger
+++ b/tools/remote_debugger
@@ -2,9 +2,10 @@
 set -e
 
 if [ "$1" = "kill" ]; then
+  ps ax -o pid,command | grep "[p]ymobiledevice3 lockdown start-tunnel" | awk '{print$1}' | xargs kill -9
   ps ax -o pid,command | grep "[p]ymobiledevice3 remote start-tunnel" | awk '{print$1}' | xargs kill -9
 elif [ "$1" = "start" ]; then
-  pymobiledevice3 remote start-tunnel --no-color --udid $2
+  pymobiledevice3 $2 start-tunnel --no-color --udid $3
 fi
 
-# @version: 1
+# @version: 2


### PR DESCRIPTION
BREAKING CHANGES: requires to update `remote_debugger` script, see: `:h xcodebuild.remote-debugger-update`