### PR TITLE
fix: start wizzard when launched from nushell

### DIFF
--- a/lua/xcodebuild/project/appdata.lua
+++ b/lua/xcodebuild/project/appdata.lua
@@ -78,7 +78,7 @@ end
 
 ---Creates the `.nvim/xcodebuild` folder if it doesn't exist.
 function M.create_app_dir()
-  util.shell("mkdir -p .nvim/xcodebuild")
+  util.shell({ "mkdir", "-p", ".nvim/xcodebuild" })
 end
 
 ---Initializes the `.nvim/xcodebuild/env.txt` file.


### PR DESCRIPTION
This fixes #345 
`.nvim/xcodebuild` directory is created using `util.shell` which in turn calls `vim.fn.jobstart`.
It is called with a String  as parameter, according to `:help jobstart`:
```
If {cmd} is a List it runs directly (no 'shell').
If {cmd} is a String it runs in the 'shell', like this: >vim
call jobstart(split(&shell) + split(&shellcmdflag) + ['{cmd}'])
```

As it turns out nushell has its own implementation of mkdir that doesn't support `-p` so calling `mkdir -p .nvim/xcodebuild` fails.
Replacing the call by:
`util.shell({ "mkdir", "-p", ".nvim/xcodebuild" })` makes nvim call the `mkdir` command in the path directly rather than go through the shell.