### PR TITLE
feat(previews)!: clear snacks.nvim image cache

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -1660,11 +1660,6 @@ UIKit (similar for AppKit):
    Alternatively, run `:XcodebuildPreviewGenerateAndShow hotReload` to keep
    the app running for hot reloading.
 
-WARNING: snacks.nvim doesn't support clearing the in-memory cache right now, which makes it
-impossible to refresh previews without restarting Neovim. If you want to use this feature,
-you either need to wait until it is added (github.com/folke/snacks.nvim/issues/1394) or
-you can use my fork where I removed the cache: wojciech-kulik/snacks.nvim.
-
 If you want to use the hot reload feature, you need to integrate your app with `Inject`,
 read more about it here: https://github.com/wojciech-kulik/xcodebuild.nvim/wiki/Tips-&-Tricks#hot-reload
 


### PR DESCRIPTION
BREAKING CHANGE: you don't need to use snacks.nvim fork anymore to see previews. The latest plugin version supports clearing cache and it can be used with xcodebuild.nvim.

Although, please note that there is a bug causing image duplication: https://github.com/folke/snacks.nvim/issues/2343