### PR TITLE
feat(dap)!: migrate codelldb to native lldb-dap

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -27,6 +27,7 @@ Project Assets Manager ····························�
 Device ············································ |xcodebuild.platform.device|
 Device Proxy ································ |xcodebuild.platform.device_proxy|
 macOS Platform Integration ························· |xcodebuild.platform.macos|
+Debugger ········································ |xcodebuild.platform.debugger|
 Autocommand Events ···························· |xcodebuild.broadcasting.events|
 Notifications ·························· |xcodebuild.broadcasting.notifications|
 Test Diagnostics ································ |xcodebuild.tests.diagnostics|
@@ -40,6 +41,8 @@ Xcresult File Parser ························ |xcodebuil
 Code Coverage ······························ |xcodebuild.code_coverage.coverage|
 Code Coverage Report ························· |xcodebuild.code_coverage.report|
 DAP Integration ·································· |xcodebuild.integrations.dap|
+DAP Configurations - lldb ······················· |xcodebuild.integrations.lldb|
+DAP Configurations - codelldb ··············· |xcodebuild.integrations.codelldb|
 DAP Symbolicate ······················ |xcodebuild.integrations.dap-symbolicate|
 Remote Debugger Integration ·········· |xcodebuild.integrations.remote_debugger|
 LSP Integration ·································· |xcodebuild.integrations.lsp|
@@ -234,6 +237,15 @@ M.setup({options})                                            *xcodebuild.setup*
           fzf_opts = {},  -- fzf options
           win_opts = {},  -- window options
         },
+        codelldb = {
+          enabled = false, -- enable codelldb dap adapter for Swift debugging
+          port = 13000, -- port used by codelldb adapter
+          codelldb_path = nil, -- path to codelldb adapter, REQUIRED
+          lldb_lib_path = "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/LLDB", -- path to lldb library
+        },
+        lldb = {
+          port = 13000, -- port used by lldb-dap
+        },
       },
       highlights = {
         -- you can override here any highlight group used by this plugin
@@ -319,7 +331,6 @@ External tools
  - `pymobiledevice3` to debug on physical devices and/or run apps on devices below iOS 17.
  - `jq` to get some information from `pymobiledevice3`.
  - `xcode-build-server` to make LSP work properly with xcodeproj/xcworkspace.
- - `codelldb` to debug applications.
  - `ripgrep` to find matching test files while using Swift Testing framework.
  - `Xcode` to build, run, and test apps. Make sure that `xcodebuild` and `xcrun simctl` work correctly. Tested with Xcode 15.
 
@@ -2708,7 +2719,7 @@ M.start_secure_server({destination}, {rsd})
   Starts the secure server.
   It is used on devices with iOS 17 and above.
 
-  Returns the command to connect to the device using `codelldb`.
+  Returns the command to connect to the device using `lldb`.
 
   Parameters: ~
     {destination}  (string) # device id
@@ -2724,7 +2735,7 @@ M.start_server({destination}, {port}, {callback})
   It is used on devices with iOS below 17.
 
   The callback returns {connection_string} that can be used to connect
-  to the device using `codelldb`.
+  to the device using `lldb`.
 
   This process must be alive during the debugging session.
   Later, it can be closed with `vim.fn.jobstop({job_id})`.
@@ -2787,15 +2798,39 @@ M.launch_app({appPath}, {callback})       *xcodebuild.platform.macos.launch_app*
 
 
                                     *xcodebuild.platform.macos.launch_and_debug*
-M.launch_and_debug({appPath}, {callback})
+M.launch_and_debug({callback})
   Starts the application on macOS and starts the debugger.
 
   Parameters: ~
-    {appPath}   (string)
     {callback}  (function|nil)
 
   Returns: ~
     (number|nil)   job id
+
+
+==============================================================================
+Debugger                                          *xcodebuild.platform.debugger*
+
+This module is responsible for providing the interface to get DAP configurations based
+on the debugger integration used (like lldb, codelldb, etc.).
+
+                              *xcodebuild.platform.debugger.DebuggerIntegration*
+DebuggerIntegration
+
+  Fields: ~
+    {get_macos_configuration}          (fun():table)
+    {get_ios_configuration}            (fun():table)
+    {get_remote_device_configuration}  (fun(request:string):table)
+    {get_adapter_name}                 (fun():string)
+    {get_adapter}                      (fun():table)
+
+
+                               *xcodebuild.platform.debugger.set_implementation*
+M.set_implementation({impl})
+  Sets the implementation for the debugger integration.
+
+  Parameters: ~
+    {impl}  (DebuggerIntegration)
 
 
 ==============================================================================
@@ -3704,9 +3739,11 @@ It provides functions to start the debugger and to manage its state.
 
 To configure `nvim-dap` for development:
 
-  1. Download `codelldb` VS Code plugin from: https://github.com/vadimcn/codelldb/releases
-     For macOS use darwin version. Just unzip vsix file and set paths below.
-  2. Install also `nvim-dap-ui` for a nice GUI to debug.
+  1. [Only for Xcode versions below 16]
+     - Download `codelldb` VS Code plugin from: https://github.com/vadimcn/codelldb/releases
+     - For macOS use Darwin version and unzip `vsix` file.
+     - Update `codelldb` integration config (node: `integrations.codelldb`).
+  2. Install `nvim-dap-ui` for a nice GUI to debug.
   3. Make sure to enable console window from `nvim-dap-ui` to see simulator logs.
 
 Sample `nvim-dap` configuration:
@@ -3717,11 +3754,7 @@ Sample `nvim-dap` configuration:
         "wojciech-kulik/xcodebuild.nvim"
       },
       config = function()
-        local xcodebuild = require("xcodebuild.integrations.dap")
-        -- SAMPLE PATH, change it to your local codelldb path
-        local codelldbPath = "/YOUR_PATH/codelldb-aarch64-darwin/extension/adapter/codelldb"
-
-        xcodebuild.setup(codelldbPath)
+        require("xcodebuild.integrations.dap").setup()
 
         vim.keymap.set("n", "<leader>dd", xcodebuild.build_and_debug, { desc = "Build & Debug" })
         vim.keymap.set("n", "<leader>dr", xcodebuild.debug_without_build, { desc = "Debug Without Building" })
@@ -3812,21 +3845,6 @@ M.debug_failing_tests()
   Starts the debugger and re-runs the failing tests.
 
 
-                                  *xcodebuild.integrations.dap.get_program_path*
-M.get_program_path()
-  Returns path to the built application.
-
-  Returns: ~
-    (string)
-
-
-M.wait_for_pid()                      *xcodebuild.integrations.dap.wait_for_pid*
-  Waits for the application to start and returns its PID.
-
-  Returns: ~
-    (thread|nil)   coroutine with pid
-
-
                                      *xcodebuild.integrations.dap.clear_console*
 M.clear_console({validate})
   Clears the DAP console buffer.
@@ -3845,42 +3863,6 @@ M.update_console({output}, {append})
   Parameters: ~
     {output}  (string[])
     {append}  (boolean|nil) # if true, appends the output to the last line
-
-
-                           *xcodebuild.integrations.dap.get_swift_configuration*
-M.get_swift_configuration()
-  Returns the `coodelldb` configuration for `nvim-dap`.
-
-  Returns: ~
-    (table[])
-
-  Usage: ~
->lua
-    require("dap").configurations.swift = require("xcodebuild.integrations.dap").get_swift_configuration()
-<
-
-
-                              *xcodebuild.integrations.dap.get_codelldb_adapter*
-M.get_codelldb_adapter({codelldbPath}, {lldbPath}, {port})
-  Returns the `codelldb` adapter for `nvim-dap`.
-
-  Examples:
-    {codelldbPath} - `/your/path/to/codelldb-aarch64-darwin/extension/adapter/codelldb`
-    {lldbPath} - (default) `/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/LLDB`
-
-  Parameters: ~
-    {codelldbPath}  (string)
-    {lldbPath}      (string|nil)
-    {port}          (number|nil)
-
-  Returns: ~
-    (table)
-
-  Usage: ~
->lua
-    require("dap").adapters.codelldb = require("xcodebuild.integrations.dap")
-      .get_codelldb_adapter("path/to/codelldb")
-<
 
 
                                   *xcodebuild.integrations.dap.save_breakpoints*
@@ -3928,20 +3910,109 @@ M.register_user_commands()
     - `XcodebuildDebug` - installs and runs the project with the debugger.
 
 
-                                             *xcodebuild.integrations.dap.setup*
-M.setup({codelldbPath}, {loadBreakpoints}, {lldbPath})
+M.setup({loadBreakpoints})                   *xcodebuild.integrations.dap.setup*
   Sets up the adapter and configuration for the `nvim-dap` plugin.
-  {codelldbPath} - path to the `codelldb` binary.
-
-  Sample {codelldbPath} - `/your/path/to/codelldb-aarch64-darwin/extension/adapter/codelldb`
   {loadBreakpoints} - if true or nil, sets up an autocmd to load breakpoints when a Swift file is opened.
-  {lldbPath} - default: `/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/LLDB`
-  Provide {lldbPath} if your Xcode installation is not in the default location.
 
   Parameters: ~
-    {codelldbPath}     (string)
     {loadBreakpoints}  (boolean|nil) default: true
-    {lldbPath}         (string|nil)
+
+
+==============================================================================
+DAP Configurations - lldb                         *xcodebuild.integrations.lldb*
+
+                                                               *xcodebuild.lldb*
+This module contains DAP configurations for `lldb-dap` provided by `xcrun lldb-dap`.
+
+                            *xcodebuild.integrations.lldb.get_ios_configuration*
+M.get_ios_configuration()
+  Returns iOS configuration for `nvim-dap`.
+
+  Returns: ~
+    (table)
+
+
+                          *xcodebuild.integrations.lldb.get_macos_configuration*
+M.get_macos_configuration()
+  Returns macOS configuration for `nvim-dap`.
+
+  Returns: ~
+    (table)
+
+
+                  *xcodebuild.integrations.lldb.get_remote_device_configuration*
+M.get_remote_device_configuration({request})
+  Returns remote debugging configuration for `nvim-dap`.
+
+  Parameters: ~
+    {request}  (string) "launch"|"attach"
+
+  Returns: ~
+    (table)
+
+
+                                 *xcodebuild.integrations.lldb.get_adapter_name*
+M.get_adapter_name()
+  Returns the name of the adapter.
+
+  Returns: ~
+    (string)
+
+
+M.get_adapter()                       *xcodebuild.integrations.lldb.get_adapter*
+  Returns the `lldb` adapter configuration for `nvim-dap`.
+
+  Returns: ~
+    (table)
+
+
+==============================================================================
+DAP Configurations - codelldb                 *xcodebuild.integrations.codelldb*
+
+                                                           *xcodebuild.codelldb*
+This module contains DAP configurations for `codelldb` DAP server.
+
+                        *xcodebuild.integrations.codelldb.get_ios_configuration*
+M.get_ios_configuration()
+  Returns iOS configuration for `nvim-dap`.
+
+  Returns: ~
+    (table)
+
+
+                      *xcodebuild.integrations.codelldb.get_macos_configuration*
+M.get_macos_configuration()
+  Returns macOS configuration for `nvim-dap`.
+
+  Returns: ~
+    (table)
+
+
+              *xcodebuild.integrations.codelldb.get_remote_device_configuration*
+M.get_remote_device_configuration({request})
+  Returns remote debugging configuration for `nvim-dap`.
+
+  Parameters: ~
+    {request}  (string) "launch"|"attach"
+
+  Returns: ~
+    (table)
+
+
+                             *xcodebuild.integrations.codelldb.get_adapter_name*
+M.get_adapter_name()
+  Returns the name of the adapter.
+
+  Returns: ~
+    (string)
+
+
+                                  *xcodebuild.integrations.codelldb.get_adapter*
+M.get_adapter()
+  Returns the `codelldb` adapter configuration for `nvim-dap`.
+
+  Returns: ~
+    (table)
 
 
 ==============================================================================
@@ -5054,6 +5125,16 @@ M.get_filename({filepath})                        *xcodebuild.util.get_filename*
     (string)
 
 
+M.shell_execute({cmd})                           *xcodebuild.util.shell_execute*
+  Runs a shell command and returns exit code
+
+  Parameters: ~
+    {cmd}  (string|string[])
+
+  Returns: ~
+    (number)
+
+
 M.shell({cmd})                                           *xcodebuild.util.shell*
   Runs a shell command and returns the output as a list of strings.
 
@@ -5064,7 +5145,7 @@ M.shell({cmd})                                           *xcodebuild.util.shell*
     (string[])
 
 
-M.shellAsync({cmd}, {callback})                     *xcodebuild.util.shellAsync*
+M.shell_async({cmd}, {callback})                   *xcodebuild.util.shell_async*
   Runs a shell command asynchronously.
 
   Parameters: ~

--- a/lua/xcodebuild/code_coverage/coverage.lua
+++ b/lua/xcodebuild/code_coverage/coverage.lua
@@ -126,7 +126,7 @@ function M.export_coverage(xcresultFilepath, callback)
     return
   end
 
-  util.shellAsync({ "rm", "-rf", appdata.coverage_report_filepath }, function()
+  util.shell_async({ "rm", "-rf", appdata.coverage_report_filepath }, function()
     xcode.export_code_coverage_report(xcresultFilepath, appdata.coverage_report_filepath, callback_if_set)
   end)
 end

--- a/lua/xcodebuild/core/config.lua
+++ b/lua/xcodebuild/core/config.lua
@@ -165,6 +165,15 @@ local defaults = {
       fzf_opts = {}, -- fzf options
       win_opts = {}, -- window options
     },
+    codelldb = {
+      enabled = false, -- enable codelldb dap adapter for Swift debugging
+      port = 13000, -- port used by codelldb adapter
+      codelldb_path = nil, -- path to codelldb adapter, REQUIRED
+      lldb_lib_path = "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/LLDB", -- path to lldb library
+    },
+    lldb = {
+      port = 13000, -- port used by lldb-dap
+    },
   },
   highlights = {
     -- you can override here any highlight group used by this plugin

--- a/lua/xcodebuild/docs/requirements.lua
+++ b/lua/xcodebuild/docs/requirements.lua
@@ -18,7 +18,6 @@
 --- - `pymobiledevice3` to debug on physical devices and/or run apps on devices below iOS 17.
 --- - `jq` to get some information from `pymobiledevice3`.
 --- - `xcode-build-server` to make LSP work properly with xcodeproj/xcworkspace.
---- - `codelldb` to debug applications.
 --- - `ripgrep` to find matching test files while using Swift Testing framework.
 --- - `Xcode` to build, run, and test apps. Make sure that `xcodebuild` and `xcrun simctl` work correctly. Tested with Xcode 15.
 ---

--- a/lua/xcodebuild/init.lua
+++ b/lua/xcodebuild/init.lua
@@ -249,6 +249,15 @@ end
 ---      fzf_opts = {},  -- fzf options
 ---      win_opts = {},  -- window options
 ---    },
+---    codelldb = {
+---      enabled = false, -- enable codelldb dap adapter for Swift debugging
+---      port = 13000, -- port used by codelldb adapter
+---      codelldb_path = nil, -- path to codelldb adapter, REQUIRED
+---      lldb_lib_path = "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/LLDB", -- path to lldb library
+---    },
+---    lldb = {
+---      port = 13000, -- port used by lldb-dap
+---    },
 ---  },
 ---  highlights = {
 ---    -- you can override here any highlight group used by this plugin

--- a/lua/xcodebuild/integrations/codelldb.lua
+++ b/lua/xcodebuild/integrations/codelldb.lua
@@ -1,0 +1,164 @@
+---@mod xcodebuild.integrations.codelldb DAP Configurations - codelldb
+---@tag xcodebuild.codelldb
+---@brief [[
+---This module contains DAP configurations for `codelldb` DAP server.
+---@brief ]]
+
+---@type DebuggerIntegration
+local M = {
+  get_macos_configuration = function()
+    return {}
+  end,
+  get_ios_configuration = function()
+    return {}
+  end,
+  get_remote_device_configuration = function(_)
+    return {}
+  end,
+  get_adapter_name = function()
+    return ""
+  end,
+  get_adapter = function()
+    return {}
+  end,
+}
+
+local appdata = require("xcodebuild.project.appdata")
+local projectConfig = require("xcodebuild.project.config")
+local config = require("xcodebuild.core.config").options.integrations.codelldb
+local notifications = require("xcodebuild.broadcasting.notifications")
+
+---Returns path to the built application.
+---@return string
+local function get_program_path()
+  return projectConfig.settings.appPath
+end
+
+---Returns iOS configuration for `nvim-dap`.
+---@return table
+function M.get_ios_configuration()
+  return {
+    name = "iOS App Debugger",
+    type = M.get_adapter_name(),
+    request = "attach",
+    cwd = vim.fn.getcwd(),
+    stopOnEntry = false,
+    waitFor = true,
+    program = get_program_path,
+  }
+end
+
+---Returns macOS configuration for `nvim-dap`.
+---@return table
+function M.get_macos_configuration()
+  return {
+    name = "macOS App Debugger",
+    type = M.get_adapter_name(),
+    args = appdata.read_run_args(),
+    env = appdata.read_env_vars(),
+    request = "launch",
+    cwd = vim.fn.getcwd(),
+    stopOnEntry = false,
+    waitFor = true,
+    program = get_program_path,
+  }
+end
+
+---Returns remote debugging configuration for `nvim-dap`.
+---@param request string "launch"|"attach"
+---@return table
+function M.get_remote_device_configuration(request)
+  local deviceProxy = require("xcodebuild.platform.device_proxy")
+  local remoteDebugger = require("xcodebuild.integrations.remote_debugger")
+  local dapConfig = {
+    name = "iOS Remote Debugger",
+    type = M.get_adapter_name(),
+    env = appdata.read_env_vars(),
+    args = appdata.read_run_args(),
+    request = request,
+    cwd = vim.fn.getcwd(),
+    stopOnEntry = false,
+    waitFor = true,
+    program = get_program_path,
+  }
+
+  dapConfig.initCommands = { "platform select remote-ios" }
+  dapConfig.targetCreateCommands = {
+    function()
+      return "target create '" .. projectConfig.settings.appPath .. "'"
+    end,
+  }
+  dapConfig.processCreateCommands = {
+    function()
+      local appPath =
+        deviceProxy.find_app_path(projectConfig.settings.destination, projectConfig.settings.bundleId)
+
+      if not appPath then
+        notifications.send_error("Failed to find the app path on the device.")
+        return "platform status"
+      end
+
+      appdata.append_app_logs({ "App path: " .. appPath })
+
+      return "script lldb.target.module[0].SetPlatformFileSpec(lldb.SBFileSpec('" .. appPath .. "'))"
+    end,
+
+    function()
+      if remoteDebugger.mode == remoteDebugger.LEGACY_MODE then
+        return remoteDebugger.connection_string
+      else
+        return deviceProxy.start_secure_server(projectConfig.settings.destination, remoteDebugger.rsd_param)
+      end
+    end,
+
+    function()
+      if request == "attach" then
+        local pid = deviceProxy.find_app_pid(projectConfig.settings.productName)
+        if not pid or pid == "" then
+          notifications.send_error("Failed to find the app PID on the device.")
+          return "platform status"
+        end
+        appdata.append_app_logs({ "App PID: " .. pid })
+
+        return "process attach -c --pid " .. pid
+      else
+        return "process launch"
+      end
+    end,
+  }
+
+  return dapConfig
+end
+
+---Returns the name of the adapter.
+---@return string
+function M.get_adapter_name()
+  return "codelldb"
+end
+
+---Returns the `codelldb` adapter configuration for `nvim-dap`.
+---@return table
+function M.get_adapter()
+  if not config.codelldb_path or not config.lldb_lib_path or not config.port then
+    notifications.send_error(
+      "xcodebuild.nvim: codelldb is not properly configured, check your settings: integrations.codelldb"
+    )
+    return {}
+  end
+
+  return {
+    type = "server",
+    port = config.port,
+    executable = {
+      command = config.codelldb_path,
+      args = {
+        "--port",
+        config.port,
+        "--liblldb",
+        config.lldb_lib_path,
+      },
+    },
+  }
+end
+
+return M

--- a/lua/xcodebuild/integrations/lldb.lua
+++ b/lua/xcodebuild/integrations/lldb.lua
@@ -1,0 +1,219 @@
+---@mod xcodebuild.integrations.lldb DAP Configurations - lldb
+---@tag xcodebuild.lldb
+---@brief [[
+---This module contains DAP configurations for `lldb-dap` provided by `xcrun lldb-dap`.
+---@brief ]]
+
+---@type DebuggerIntegration
+local M = {
+  get_macos_configuration = function()
+    return {}
+  end,
+  get_ios_configuration = function()
+    return {}
+  end,
+  get_remote_device_configuration = function(_)
+    return {}
+  end,
+  get_adapter_name = function()
+    return ""
+  end,
+  get_adapter = function()
+    return {}
+  end,
+}
+
+local util = require("xcodebuild.util")
+local appdata = require("xcodebuild.project.appdata")
+local constants = require("xcodebuild.core.constants")
+local config = require("xcodebuild.core.config").options.integrations.lldb
+local notifications = require("xcodebuild.broadcasting.notifications")
+local projectConfig = require("xcodebuild.project.config")
+
+---Returns path to the built application.
+---@return string
+local function get_program_path()
+  return projectConfig.settings.appPath
+end
+
+---Waits for the application to start and returns its PID.
+---@return thread|nil # coroutine with pid
+local function wait_for_pid()
+  local co = coroutine
+  local productName = projectConfig.settings.productName
+  local xcode = require("xcodebuild.core.xcode")
+
+  if not productName then
+    notifications.send_error("You must build the application first")
+    return
+  end
+
+  return co.create(function(dap_run_co)
+    local pid = nil
+    local isDevice = constants.is_device(projectConfig.settings.platform)
+
+    notifications.send("Attaching debugger...")
+    for _ = 1, 10 do
+      util.shell("sleep 1")
+
+      if isDevice then
+        pid = require("xcodebuild.platform.device_proxy").find_app_pid(productName)
+      else
+        pid = xcode.get_app_pid(productName, projectConfig.settings.platform)
+      end
+
+      if tonumber(pid) then
+        break
+      end
+    end
+
+    if not tonumber(pid) then
+      notifications.send_error("Launching the application timed out")
+
+      ---@diagnostic disable-next-line: deprecated
+      co.close(dap_run_co)
+    end
+
+    co.resume(dap_run_co, pid)
+  end)
+end
+
+---Returns iOS configuration for `nvim-dap`.
+---@return table
+function M.get_ios_configuration()
+  return {
+    name = "iOS App Debugger",
+    type = M.get_adapter_name(),
+    request = "attach",
+    cwd = vim.fn.getcwd(),
+    stopOnEntry = false,
+    waitFor = true,
+    program = get_program_path,
+    pid = wait_for_pid,
+  }
+end
+
+---Returns macOS configuration for `nvim-dap`.
+---@return table
+function M.get_macos_configuration()
+  return {
+    name = "macOS App Debugger",
+    type = M.get_adapter_name(),
+    args = appdata.read_run_args(),
+    env = appdata.read_env_vars(),
+    request = "launch",
+    cwd = vim.fn.getcwd(),
+    stopOnEntry = false,
+    waitFor = true,
+    program = get_program_path,
+  }
+end
+
+---Returns remote debugging configuration for `nvim-dap`.
+---@param request string "launch"|"attach"
+---@return table
+function M.get_remote_device_configuration(request)
+  local deviceProxy = require("xcodebuild.platform.device_proxy")
+  local remoteDebugger = require("xcodebuild.integrations.remote_debugger")
+  local dapConfig = {
+    name = "iOS Remote Debugger",
+    type = M.get_adapter_name(),
+    request = request,
+    cwd = vim.fn.getcwd(),
+    stopOnEntry = false,
+    waitFor = true,
+    program = get_program_path,
+  }
+
+  dapConfig.initCommands = { "platform select remote-ios" }
+  dapConfig.preRunCommands = {
+    function()
+      return "target create '" .. projectConfig.settings.appPath .. "'"
+    end,
+
+    function()
+      local appPath =
+        deviceProxy.find_app_path(projectConfig.settings.destination, projectConfig.settings.bundleId)
+
+      if not appPath then
+        notifications.send_error("Failed to find the app path on the device.")
+        return "platform status"
+      end
+
+      appdata.append_app_logs({ "App path: " .. appPath })
+
+      return "script lldb.target.module[0].SetPlatformFileSpec(lldb.SBFileSpec('" .. appPath .. "'))"
+    end,
+
+    function()
+      if remoteDebugger.mode == remoteDebugger.LEGACY_MODE then
+        return remoteDebugger.connection_string
+      else
+        return deviceProxy.start_secure_server(projectConfig.settings.destination, remoteDebugger.rsd_param)
+      end
+    end,
+  }
+
+  if request == "attach" then
+    dapConfig.attachCommands = {
+      function()
+        local pid = deviceProxy.find_app_pid(projectConfig.settings.productName)
+        if not pid or pid == "" then
+          notifications.send_error("Failed to find the app PID on the device.")
+          return "platform status"
+        end
+        appdata.append_app_logs({ "App PID: " .. pid })
+
+        return "process attach --pid " .. pid
+      end,
+    }
+  else
+    local env = appdata.read_env_vars()
+    local args = appdata.read_run_args()
+    local envString = ""
+    local argsString = ""
+
+    if env then
+      for k, v in pairs(env) do
+        envString = string.format("%s -E '%s=%s'", envString, k, v)
+      end
+    end
+
+    if args then
+      for _, v in ipairs(args) do
+        argsString = argsString .. " " .. v
+      end
+    end
+
+    dapConfig.launchCommands = {
+      "process launch --stop-at-entry" .. envString .. argsString,
+    }
+  end
+
+  return dapConfig
+end
+
+---Returns the name of the adapter.
+---@return string
+function M.get_adapter_name()
+  return "lldb-dap"
+end
+
+---Returns the `lldb` adapter configuration for `nvim-dap`.
+---@return table
+function M.get_adapter()
+  return {
+    type = "server",
+    port = config.port,
+    executable = {
+      command = "xcrun",
+      args = {
+        "lldb-dap",
+        "--port",
+        config.port,
+      },
+    },
+  }
+end
+
+return M

--- a/lua/xcodebuild/platform/debugger.lua
+++ b/lua/xcodebuild/platform/debugger.lua
@@ -1,0 +1,42 @@
+---@mod xcodebuild.platform.debugger Debugger
+---@brief [[
+---This module is responsible for providing the interface to get DAP configurations based
+---on the debugger integration used (like lldb, codelldb, etc.).
+---@brief ]]
+
+---@class DebuggerIntegration
+---@field get_macos_configuration fun() : table
+---@field get_ios_configuration fun() : table
+---@field get_remote_device_configuration fun(request: string) : table
+---@field get_adapter_name fun() : string
+---@field get_adapter fun() : table
+
+local M = {
+  get_macos_configuration = function()
+    return {}
+  end,
+  get_ios_configuration = function()
+    return {}
+  end,
+  get_remote_device_configuration = function(_)
+    return {}
+  end,
+  get_adapter_name = function()
+    return ""
+  end,
+  get_adapter = function()
+    return {}
+  end,
+}
+
+---Sets the implementation for the debugger integration.
+---@param impl DebuggerIntegration
+function M.set_implementation(impl)
+  M.get_macos_configuration = impl.get_macos_configuration
+  M.get_ios_configuration = impl.get_ios_configuration
+  M.get_remote_device_configuration = impl.get_remote_device_configuration
+  M.get_adapter_name = impl.get_adapter_name
+  M.get_adapter = impl.get_adapter
+end
+
+return M

--- a/lua/xcodebuild/platform/device.lua
+++ b/lua/xcodebuild/platform/device.lua
@@ -38,7 +38,7 @@ local function launch_app(waitForDebugger, callback)
 
   if settings.platform == constants.Platform.MACOS then
     if waitForDebugger then
-      return macos.launch_and_debug(settings.appPath, finished)
+      return macos.launch_and_debug(finished)
     else
       vim.defer_fn(function()
         macos.launch_app(settings.appPath, finished)

--- a/lua/xcodebuild/platform/device_proxy.lua
+++ b/lua/xcodebuild/platform/device_proxy.lua
@@ -461,7 +461,7 @@ end
 ---Starts the secure server.
 ---It is used on devices with iOS 17 and above.
 ---
----Returns the command to connect to the device using `codelldb`.
+---Returns the command to connect to the device using `lldb`.
 ---@param destination string # device id
 ---@param rsd string # rsd parameter
 ---@return string|nil # connection command
@@ -496,7 +496,7 @@ end
 ---It is used on devices with iOS below 17.
 ---
 ---The callback returns {connection_string} that can be used to connect
----to the device using `codelldb`.
+---to the device using `lldb`.
 ---
 ---This process must be alive during the debugging session.
 ---Later, it can be closed with `vim.fn.jobstop({job_id})`.

--- a/lua/xcodebuild/platform/macos.lua
+++ b/lua/xcodebuild/platform/macos.lua
@@ -7,6 +7,8 @@ local util = require("xcodebuild.util")
 local appdata = require("xcodebuild.project.appdata")
 local notifications = require("xcodebuild.broadcasting.notifications")
 
+local PLUGIN_ID = "xcodebuild-macos-debugger"
+
 local M = {}
 
 ---Simply starts the application on macOS.
@@ -76,11 +78,11 @@ function M.launch_app(appPath, callback)
 end
 
 ---Starts the application on macOS and starts the debugger.
----@param appPath string
 ---@param callback function|nil
 ---@return number|nil # job id
-function M.launch_and_debug(appPath, callback)
+function M.launch_and_debug(callback)
   local success, dap = pcall(require, "dap")
+  local debugger = require("xcodebuild.platform.debugger")
 
   if not success then
     error("xcodebuild.nvim: Could not load nvim-dap plugin")
@@ -89,18 +91,22 @@ function M.launch_and_debug(appPath, callback)
 
   appdata.clear_app_logs()
 
-  dap.run({
-    name = "macOS Debugger",
-    type = "codelldb",
-    request = "launch",
-    cwd = "${workspaceFolder}",
-    program = appPath,
-    args = appdata.read_run_args(),
-    stopOnEntry = false,
-    waitFor = true,
-    env = appdata.read_env_vars(),
-  })
+  dap.listeners.after.event_output[PLUGIN_ID] = function(_, body)
+    if not body or not body.output then
+      return
+    end
 
+    local message, _ = body.output:gsub("\r", "")
+    local lines = vim.split(message, "\n", { plain = true, trimempty = true })
+    appdata.append_app_logs(lines)
+  end
+
+  dap.listeners.after.event_exited[PLUGIN_ID] = function()
+    dap.listeners.after.event_output[PLUGIN_ID] = nil
+    dap.listeners.after.event_disconnect[PLUGIN_ID] = nil
+  end
+
+  dap.run(debugger.get_macos_configuration())
   util.call(callback)
 end
 

--- a/lua/xcodebuild/util.lua
+++ b/lua/xcodebuild/util.lua
@@ -193,6 +193,21 @@ function M.get_filename(filepath)
   return string.match(filepath, ".*%/([^/]*)%..+$")
 end
 
+---Runs a shell command and returns exit code
+---@param cmd string|string[]
+---@return number
+function M.shell_execute(cmd)
+  local result
+  local jobid = vim.fn.jobstart(cmd, {
+    on_exit = function(_, exit_code, _)
+      result = exit_code
+    end,
+  })
+  vim.fn.jobwait({ jobid })
+
+  return result or -1
+end
+
 ---Runs a shell command and returns the output as a list of strings.
 ---@param cmd string|string[]
 ---@return string[]
@@ -212,7 +227,7 @@ end
 ---Runs a shell command asynchronously.
 ---@param cmd string|string[]
 ---@param callback function|nil
-function M.shellAsync(cmd, callback)
+function M.shell_async(cmd, callback)
   vim.fn.jobstart(cmd, {
     on_exit = callback,
   })

--- a/scripts/help-update.sh
+++ b/scripts/help-update.sh
@@ -30,6 +30,7 @@ lemmy-help \
   ./lua/xcodebuild/platform/device.lua \
   ./lua/xcodebuild/platform/device_proxy.lua \
   ./lua/xcodebuild/platform/macos.lua \
+  ./lua/xcodebuild/platform/debugger.lua \
   ./lua/xcodebuild/broadcasting/events.lua \
   ./lua/xcodebuild/broadcasting/notifications.lua \
   ./lua/xcodebuild/tests/diagnostics.lua \
@@ -43,6 +44,8 @@ lemmy-help \
   ./lua/xcodebuild/code_coverage/coverage.lua \
   ./lua/xcodebuild/code_coverage/report.lua \
   ./lua/xcodebuild/integrations/dap.lua \
+  ./lua/xcodebuild/integrations/lldb.lua \
+  ./lua/xcodebuild/integrations/codelldb.lua \
   ./lua/xcodebuild/integrations/dap-symbolicate.lua \
   ./lua/xcodebuild/integrations/remote_debugger.lua \
   ./lua/xcodebuild/integrations/lsp.lua \


### PR DESCRIPTION
BREAKING CHANGE:
The plugin now relies by default on native lldb-dap server available in Xcode 16+. If you still use older Xcode version, you can enable codelldb integration in the plugin config. See `:h xcodebuild.config`.

Please also update your dap configuration. Now,
`require("xcodebuild.dap").setup` funnction allows just one optional boolean parameter: `loadBreakpoints`.