### PR TITLE
fix(parser): support concise [x] build errors for quickfix fallback

### DIFF
--- a/specs/parser_spec.lua
+++ b/specs/parser_spec.lua
@@ -255,6 +255,13 @@ describe("ENSURE parse_logs", function()
         assert.are.same(expectedResult, result)
       end)
     end)
+
+    describe("because of concise formatter output", function()
+      it("THEN should set build errors", function()
+        local expectedResult, result = runTestCase(29)
+        assert.are.same(expectedResult, result)
+      end)
+    end)
   end)
 
   --

--- a/specs/parser_test_data/tc29.log
+++ b/specs/parser_test_data/tc29.log
@@ -1,0 +1,6 @@
+/Users/john/repositories/calendar-app-ios/CalendarAppSDK/Features/CalendarAppEventCode/Sources/Sample.swift:10:5: warning: value 'tmp' was never used
+
+/Users/john/repositories/calendar-app-ios/CalendarAppSDK/Features/CalendarAppEventCode/Sources/Sample.swift:10:5: warning: value 'tmp' was never used
+
+[x] /Users/john/repositories/calendar-app-ios/CalendarAppSDK/Features/CalendarAppEventCode/Sources/Sample.swift:12:34: missing argument for parameter 'onClose' in call
+** BUILD FAILED **

--- a/specs/parser_test_data/tc29_out.log
+++ b/specs/parser_test_data/tc29_out.log
@@ -1,0 +1,22 @@
+{
+  buildErrors = { {
+      columnNumber = 34,
+      filename = "Sample",
+      filepath = "/Users/john/repositories/calendar-app-ios/CalendarAppSDK/Features/CalendarAppEventCode/Sources/Sample.swift",
+      lineNumber = 12,
+      message = { "missing argument for parameter 'onClose' in call" }
+    } },
+  buildWarnings = { {
+      columnNumber = 5,
+      filename = "Sample",
+      filepath = "/Users/john/repositories/calendar-app-ios/CalendarAppSDK/Features/CalendarAppEventCode/Sources/Sample.swift",
+      lineNumber = 10,
+      message = { "value 'tmp' was never used" }
+    } },
+  failedTestsCount = 0,
+  output = {},
+  testErrors = {},
+  tests = {},
+  testsCount = 0,
+  usesSwiftTesting = false
+}


### PR DESCRIPTION
I recently updated xcbeautify, and build errors stopped appearing in the quickfix list.
This PR adds a fallback parser for concise formatter diagnostics (for example, [x] /path/File.swift:line:col: message) so build errors are reliably captured and added to quickfix.
I couldn’t identify a single xcbeautify release that introduced this behavior, but this change fixes the issue with xcbeautify 3.1.4 and keeps existing parsing behavior intact.