### PR TITLE
feat(config): add `search_config_in_parent_dirs` option

### DIFF
--- a/doc/xcodebuild.txt
+++ b/doc/xcodebuild.txt
@@ -91,6 +91,7 @@ M.setup({options})                                            *xcodebuild.setup*
       restore_on_start = true, -- logs, diagnostics, and marks will be loaded on VimEnter (may affect performance)
       auto_save = true, -- save all buffers before running build or tests (command: silent wa!)
       store_config_in_project_dir = true, -- if true, the configuration directory is stored in the project directory. If false, it's stored in a global nvim data directory
+      search_config_in_parent_dirs = false, -- search for configuration in parent directories
       show_build_progress_bar = true, -- shows [ ...    ] progress bar during build, based on the last duration
       prepare_snapshot_test_previews = true, -- prepares a list with failing snapshot tests
       test_search = {

--- a/lua/xcodebuild/core/config.lua
+++ b/lua/xcodebuild/core/config.lua
@@ -14,6 +14,7 @@ local defaults = {
   restore_on_start = true, -- logs, diagnostics, and marks will be loaded on VimEnter (may affect performance)
   auto_save = true, -- save all buffers before running build or tests (command: silent wa!)
   store_config_in_project_dir = true, -- if true, the configuration directory is stored in the project directory. If false, it's stored in a global nvim data directory
+  search_config_in_parent_dirs = false, -- search for configuration in parent directories
   show_build_progress_bar = true, -- shows [ ...    ] progress bar during build, based on the last duration
   prepare_snapshot_test_previews = true, -- prepares a list with failing snapshot tests
   test_search = {

--- a/lua/xcodebuild/init.lua
+++ b/lua/xcodebuild/init.lua
@@ -102,6 +102,7 @@ end
 ---  restore_on_start = true, -- logs, diagnostics, and marks will be loaded on VimEnter (may affect performance)
 ---  auto_save = true, -- save all buffers before running build or tests (command: silent wa!)
 ---  store_config_in_project_dir = true, -- if true, the configuration directory is stored in the project directory. If false, it's stored in a global nvim data directory
+---  search_config_in_parent_dirs = false, -- search for configuration in parent directories
 ---  show_build_progress_bar = true, -- shows [ ...    ] progress bar during build, based on the last duration
 ---  prepare_snapshot_test_previews = true, -- prepares a list with failing snapshot tests
 ---  test_search = {

--- a/lua/xcodebuild/project/appdata.lua
+++ b/lua/xcodebuild/project/appdata.lua
@@ -38,17 +38,40 @@ local util = require("xcodebuild.util")
 
 local M = {}
 
+-- Returns the path to the `{appdir}` folder based on the current working directory (`cwd`) and the configuration options.
+--- @param cwd string current working directory
+--- @return string path to the `{appdir}` folder
+local function get_appdir_for(cwd)
+  local config = require("xcodebuild.core.config").options
+
+  if config.store_config_in_project_dir then
+    return cwd .. "/.nvim/xcodebuild"
+  else
+    local data_dir = vim.fn.stdpath("data") .. "/xcodebuild"
+    local id = util.hash(cwd)
+    local dirName = vim.fn.fnamemodify(cwd, ":t")
+    return data_dir .. "/" .. dirName .. "-" .. id
+  end
+end
+
 function M.setup()
   local config = require("xcodebuild.core.config").options
 
   local appdir
-  if config.store_config_in_project_dir then
-    appdir = vim.fn.getcwd() .. "/.nvim/xcodebuild"
-  else
-    local data_dir = vim.fn.stdpath("data") .. "/xcodebuild"
-    local id = util.hash(vim.fn.getcwd())
-    local dirName = vim.fn.fnamemodify(vim.fn.getcwd(), ":t")
-    appdir = data_dir .. "/" .. dirName .. "-" .. id
+  local cwd = vim.fn.getcwd()
+  local parentDir = cwd
+
+  repeat
+    cwd = parentDir
+    appdir = get_appdir_for(cwd)
+    parentDir = vim.fn.fnamemodify(cwd, ":h")
+  until not config.search_config_in_parent_dirs
+    or parentDir == cwd -- reached the root
+    or util.file_exists(appdir .. "/settings.json")
+
+  -- if we reached the root and we didn't find any config, we use the appdir for the original cwd
+  if parentDir == cwd then
+    appdir = get_appdir_for(vim.fn.getcwd())
   end
 
   M.report = {


### PR DESCRIPTION
When enabled, the plugin will search for configuration in parent directories allowing you to use a different cwd from where the config directory is stored.

Resolves #421