### PR TITLE
Swift Testing support for "currentTests"

### DIFF
--- a/lua/xcodebuild/tests/provider.lua
+++ b/lua/xcodebuild/tests/provider.lua
@@ -37,6 +37,7 @@ function M.find_tests(opts)
 
   for _, line in ipairs(lines) do
     selectedClass = string.match(line, "^[^/]*class ([^:%s]+)%s*:?")
+      or string.match(line, "^[^/]*struct ([^:%s]+)%s*:?")
     if selectedClass then
       break
     end
@@ -71,6 +72,23 @@ function M.find_tests(opts)
           class = selectedClass,
         })
         break
+      elseif string.find(lines[i], "@Test", 1, true) then
+        test = string.match(lines[i], "func (.+)%(")
+        if test then
+          table.insert(selectedTests, {
+            name = test,
+            class = selectedClass,
+          })
+          break
+        end
+        test = string.match(lines[i + 1], "func (.+)%(")
+        if test then
+          table.insert(selectedTests, {
+            name = test,
+            class = selectedClass,
+          })
+          break
+        end
       end
     end
   elseif opts.failingTests and appdata.report.failedTestsCount > 0 then

--- a/lua/xcodebuild/tests/provider.lua
+++ b/lua/xcodebuild/tests/provider.lua
@@ -81,6 +81,7 @@ function M.find_tests(opts)
           })
           break
         end
+
         test = string.match(lines[i + 1], "func (.+)%(")
         if test then
           table.insert(selectedTests, {

--- a/specs/test_provider_spec.lua
+++ b/specs/test_provider_spec.lua
@@ -41,13 +41,13 @@ describe("xcodebuild.tests.provider.find_tests", function()
     before_each(function()
       mock_buffer = [[
         class MyTests: XCTestCase {
-          func testOne() {
-              XCTAssert(true)
-          }
+            func testOne() {
+                 XCTAssert(true)
+            }
 
-          func testTwo() {
-            XCTAssert(false)
-          }
+            func testTwo() {
+                 XCTAssert(false)
+            }
         }
       ]]
     end)
@@ -72,17 +72,17 @@ describe("xcodebuild.tests.provider.find_tests", function()
   describe("WHEN selecting current test in a Swift Testing file", function()
     before_each(function()
       mock_buffer = [[
-				struct TestSuite {
-					@Test func itPasses() {
-						#expect(true)
-					}
+        struct TestSuite {
+            @Test func itPasses() {
+                #expect(true)
+            }
 
-					@Test 
-					func itFails() {
-						#expect(false)
-					}
-				}
-			]]
+            @Test
+            func itFails() {
+                #expect(false)
+            }
+        }
+      ]]
     end)
 
     it("THEN tests are identified when @Test annotation is on same line", function()

--- a/specs/test_provider_spec.lua
+++ b/specs/test_provider_spec.lua
@@ -1,0 +1,105 @@
+---@diagnostic disable: duplicate-set-field
+
+local assert = require("luassert")
+local provider = require("xcodebuild.tests.provider")
+
+local busted = require("plenary.busted")
+local before_each = busted.before_each
+local after_each = busted.after_each
+local it = busted.it
+local describe = busted.describe
+
+
+describe("xcodebuild.tests.provider.find_tests", function()
+	local original_get_lines
+	local original_get_cursor
+
+	local mock_buffer = "" -- tests can assign a mock buffer here
+	local mock_cursor = { 1, 0 } -- tests can simulate cursor position here
+
+	before_each(function()
+		original_get_lines = vim.api.nvim_buf_get_lines
+		original_get_cursor = vim.api.nvim_win_get_cursor
+		vim.api.nvim_win_get_cursor = function(_)
+			return mock_cursor
+		end
+
+		vim.api.nvim_buf_get_lines = function(_, _, _, _)
+			local lines = {}
+			for line in mock_buffer:gmatch("([^\n]+)") do
+				table.insert(lines, line)
+			end
+			return lines
+		end
+	end)
+
+	after_each(function()
+		vim.api.nvim_buf_get_lines = original_get_lines
+		vim.api.nvim_win_get_cursor = original_get_cursor
+	end)
+
+	describe("WHEN selecting current test in an XCTest file", function()
+		before_each(function()
+			mock_buffer = [[
+			class MyTests: XCTestCase {
+				func testOne() {
+				    XCTAssert(true)
+				}
+
+				func testTwo() {
+					XCTAssert(false)
+				}
+			}			
+		]]
+		end)
+
+		it("THEN the first test can be identified", function()
+			mock_cursor = { 3, 0 }
+
+			local class, tests = provider.find_tests { currentTest = true }
+			assert.are.same(class, "MyTests")
+			assert.are.same(tests, { { class = "MyTests", name = "testOne" } })
+		end)
+
+		it("THEN the last test can be identified", function()
+			mock_cursor = { 7, 0 }
+
+			local class, tests = provider.find_tests { currentTest = true }
+			assert.are.same(class, "MyTests")
+			assert.are.same(tests, { { class = "MyTests", name = "testTwo" } })
+		end)
+	end)
+
+	describe("WHEN selecting current test in a Swift Testing file", function()
+		before_each(function()
+			mock_buffer = [[
+				struct TestSuite {
+					@Test func itPasses() {
+						#expect(true)
+					}
+
+					@Test 
+					func itFails() {
+						#expect(false)
+					}
+				}
+			]]
+		end)
+
+		it("THEN tests are identified when @Test annotation is on same line", function()
+			mock_cursor = { 3, 0 }
+
+			local class, tests = provider.find_tests { currentTest = true }
+			assert.are.same(class, "TestSuite")
+			assert.are.same(tests, { { class = "TestSuite", name = "itPasses" }})
+		end)
+
+		it("THEN tests are identified when @Test annotation is on previous line", function()
+			mock_cursor = { 7, 0 }
+
+			local class, tests = provider.find_tests { currentTest = true }
+			assert.are.same(class, "TestSuite")
+			assert.are.same(tests, { { class = "TestSuite", name = "itFails" }})
+		end)
+	end)
+end)

--- a/specs/test_provider_spec.lua
+++ b/specs/test_provider_spec.lua
@@ -40,16 +40,16 @@ describe("xcodebuild.tests.provider.find_tests", function()
   describe("WHEN selecting current test in an XCTest file", function()
     before_each(function()
       mock_buffer = [[
-			class MyTests: XCTestCase {
-				func testOne() {
-				    XCTAssert(true)
-				}
+        class MyTests: XCTestCase {
+          func testOne() {
+              XCTAssert(true)
+          }
 
-				func testTwo() {
-					XCTAssert(false)
-				}
-			}			
-		]]
+          func testTwo() {
+            XCTAssert(false)
+          }
+        }
+      ]]
     end)
 
     it("THEN the first test can be identified", function()

--- a/specs/test_provider_spec.lua
+++ b/specs/test_provider_spec.lua
@@ -9,38 +9,37 @@ local after_each = busted.after_each
 local it = busted.it
 local describe = busted.describe
 
-
 describe("xcodebuild.tests.provider.find_tests", function()
-	local original_get_lines
-	local original_get_cursor
+  local original_get_lines
+  local original_get_cursor
 
-	local mock_buffer = "" -- tests can assign a mock buffer here
-	local mock_cursor = { 1, 0 } -- tests can simulate cursor position here
+  local mock_buffer = "" -- tests can assign a mock buffer here
+  local mock_cursor = { 1, 0 } -- tests can simulate cursor position here
 
-	before_each(function()
-		original_get_lines = vim.api.nvim_buf_get_lines
-		original_get_cursor = vim.api.nvim_win_get_cursor
-		vim.api.nvim_win_get_cursor = function(_)
-			return mock_cursor
-		end
+  before_each(function()
+    original_get_lines = vim.api.nvim_buf_get_lines
+    original_get_cursor = vim.api.nvim_win_get_cursor
+    vim.api.nvim_win_get_cursor = function(_)
+      return mock_cursor
+    end
 
-		vim.api.nvim_buf_get_lines = function(_, _, _, _)
-			local lines = {}
-			for line in mock_buffer:gmatch("([^\n]+)") do
-				table.insert(lines, line)
-			end
-			return lines
-		end
-	end)
+    vim.api.nvim_buf_get_lines = function(_, _, _, _)
+      local lines = {}
+      for line in mock_buffer:gmatch("([^\n]+)") do
+        table.insert(lines, line)
+      end
+      return lines
+    end
+  end)
 
-	after_each(function()
-		vim.api.nvim_buf_get_lines = original_get_lines
-		vim.api.nvim_win_get_cursor = original_get_cursor
-	end)
+  after_each(function()
+    vim.api.nvim_buf_get_lines = original_get_lines
+    vim.api.nvim_win_get_cursor = original_get_cursor
+  end)
 
-	describe("WHEN selecting current test in an XCTest file", function()
-		before_each(function()
-			mock_buffer = [[
+  describe("WHEN selecting current test in an XCTest file", function()
+    before_each(function()
+      mock_buffer = [[
 			class MyTests: XCTestCase {
 				func testOne() {
 				    XCTAssert(true)
@@ -51,28 +50,28 @@ describe("xcodebuild.tests.provider.find_tests", function()
 				}
 			}			
 		]]
-		end)
+    end)
 
-		it("THEN the first test can be identified", function()
-			mock_cursor = { 3, 0 }
+    it("THEN the first test can be identified", function()
+      mock_cursor = { 3, 0 }
 
-			local class, tests = provider.find_tests { currentTest = true }
-			assert.are.same(class, "MyTests")
-			assert.are.same(tests, { { class = "MyTests", name = "testOne" } })
-		end)
+      local class, tests = provider.find_tests({ currentTest = true })
+      assert.are.same(class, "MyTests")
+      assert.are.same(tests, { { class = "MyTests", name = "testOne" } })
+    end)
 
-		it("THEN the last test can be identified", function()
-			mock_cursor = { 7, 0 }
+    it("THEN the last test can be identified", function()
+      mock_cursor = { 7, 0 }
 
-			local class, tests = provider.find_tests { currentTest = true }
-			assert.are.same(class, "MyTests")
-			assert.are.same(tests, { { class = "MyTests", name = "testTwo" } })
-		end)
-	end)
+      local class, tests = provider.find_tests({ currentTest = true })
+      assert.are.same(class, "MyTests")
+      assert.are.same(tests, { { class = "MyTests", name = "testTwo" } })
+    end)
+  end)
 
-	describe("WHEN selecting current test in a Swift Testing file", function()
-		before_each(function()
-			mock_buffer = [[
+  describe("WHEN selecting current test in a Swift Testing file", function()
+    before_each(function()
+      mock_buffer = [[
 				struct TestSuite {
 					@Test func itPasses() {
 						#expect(true)
@@ -84,22 +83,22 @@ describe("xcodebuild.tests.provider.find_tests", function()
 					}
 				}
 			]]
-		end)
+    end)
 
-		it("THEN tests are identified when @Test annotation is on same line", function()
-			mock_cursor = { 3, 0 }
+    it("THEN tests are identified when @Test annotation is on same line", function()
+      mock_cursor = { 3, 0 }
 
-			local class, tests = provider.find_tests { currentTest = true }
-			assert.are.same(class, "TestSuite")
-			assert.are.same(tests, { { class = "TestSuite", name = "itPasses" }})
-		end)
+      local class, tests = provider.find_tests({ currentTest = true })
+      assert.are.same(class, "TestSuite")
+      assert.are.same(tests, { { class = "TestSuite", name = "itPasses" } })
+    end)
 
-		it("THEN tests are identified when @Test annotation is on previous line", function()
-			mock_cursor = { 7, 0 }
+    it("THEN tests are identified when @Test annotation is on previous line", function()
+      mock_cursor = { 7, 0 }
 
-			local class, tests = provider.find_tests { currentTest = true }
-			assert.are.same(class, "TestSuite")
-			assert.are.same(tests, { { class = "TestSuite", name = "itFails" }})
-		end)
-	end)
+      local class, tests = provider.find_tests({ currentTest = true })
+      assert.are.same(class, "TestSuite")
+      assert.are.same(tests, { { class = "TestSuite", name = "itFails" } })
+    end)
+  end)
 end)


### PR DESCRIPTION
Hi! I noticed that triggering tests using `:XcodebuildTestNearest` wouldn't work with my Swift Testing suites.

Here are my changes to get it working, along with some tests.